### PR TITLE
优化待翻译的文本中可能被误识别为 prompt 的情况

### DIFF
--- a/plugins/web3.yml
+++ b/plugins/web3.yml
@@ -53,7 +53,7 @@ env:
         {{imt_sub_source_field}}: ...
 systemPrompt: You are a highly skilled translation engine with expertise in the Web3 sector. Your function is to accurately translate Web3 texts into the target language specified, maintaining the original format, technical terms, and abbreviations. Do not add any explanations or annotations to the translated text.
 prompt: |-
-  Please translate the following text into {{to}}. Retain the original paragraph formatting, technical terms (e.g., ETH, DeFi), and company abbreviations (e.g., BTC, DAO). Do not add explanations or annotations:
+  Please translate the following text into {{to}}. Retain the original paragraph formatting, technical terms (e.g., ETH, DeFi), and company abbreviations (e.g., BTC, DAO). Do not add explanations or annotations(The text after the colon will be translated):
 
   {{text}}
 


### PR DESCRIPTION
### 优化待翻译的文本中可能被误识别为 prompt 的情况
> 供参考，若有更佳可关闭

#### 复现
翻译文本（单独翻译，为了效果换行）：
Detailed explanation

> 复现网站 [https://github.com/changesets/changesets?tab=readme-ov-file#documentation](https://github.com/changesets/changesets?tab=readme-ov-file#documentation)

#### 修复前后对比
虽然 AI 专家选项不一致，但内容一致

##### 修复前

<img width="1875" alt="截屏2024-05-20 下午10 53 39" src="https://github.com/immersive-translate/prompts/assets/41893166/47fdc11c-e94f-4c42-b55a-9a340aff2a33">

##### 修复后
<img width="1875" alt="截屏2024-05-20 下午10 53 57" src="https://github.com/immersive-translate/prompts/assets/41893166/01b935ec-44a0-49ed-a462-54dead3e2963">
