### PR TITLE
增加词汇助手插件

### DIFF
--- a/plugins/VocabularyAssistant.yml
+++ b/plugins/VocabularyAssistant.yml
@@ -1,0 +1,136 @@
+id: VocabularyAssistant
+version: 1.0.1
+extensionVersion: 1.4.10
+name: Vocabulary Assistant
+description: Provide phonetic transcription and chinese translation for difficult words in the current paragraph
+avatar: https://s.immersivetranslate.com/assets/uploads/fluent-7JVve6.png
+author: Official
+homepage: https://immersivetranslate.com/
+details: |-
+  This expert is specialized in phonetic transcription and chinese translation for difficult words in the current paragraph. 
+i18n: 
+  zh-CN:
+    name: 词汇助手
+    description: 为段落中的疑难单词提供音标翻译和中文翻译
+    details: |-
+      为疑难单词提供音标翻译和中文翻译，帮助读者更好地理解和理解疑难的单词。该助手非常适合读者，包括学生、教师和其他需要翻译的人。
+  zh-TW:
+    name: 詞彙助手
+    description: 為段落中的疑难詞彙提供音標翻譯和中文翻譯
+    details: |-
+      為疑难詞彙提供音標翻譯和中文翻譯，幫助讀者更好地理解和理解疑难的詞彙。詞彙助手非常適合讀者，包括學生、教師和其他需要翻譯的人。
+env:
+  imt_source_field: source
+  imt_trans_field: vocabulary_set
+  imt_sub_source_field: source
+  imt_sub_trans_field: vocabulary_set
+  imt_yaml_item: |-
+    - id: {{id}}
+      {{imt_source_field}}: {{text}}
+  imt_subtitle_yaml_item: |-
+    - id: {{id}}
+      {{imt_sub_source_field}}: {{text}}
+  normal_result_yaml_example: |-
+    Example request:
+      - id: 1
+        {{imt_source_field}}: No cyclist had to tell me how traumatic it was. I could just see it.
+    Example result:
+      - id: 1
+        {{imt_trans_field}}: 1. cyclist /ˈsaɪ.klɪst/ 骑行者; 2. traumatic /ˈtræktʃərɪf/ 令人厌烦的; 
+  subtitle_result_yaml_example: |-
+    Example request:
+      - id: 1
+        {{imt_sub_source_field}}: No cyclist had to tell me how traumatic it was. I could just see it.
+      - id: 2
+        {{imt_sub_source_field}}: However, chronic repeated saddle sores can eventually lead to scarring, or even lumps that need to be surgically excised as the body consolidates swelling
+    Example result:
+      - id: 1
+        {{imt_sub_trans_field}}: 1. cyclist /ˈsaɪ.klɪst/ 骑行者; 2. traumatic /ˈtræktʃərɪf/ 令人厌烦的; 
+        {{imt_sub_source_field}}: No cyclist had to tell me how traumatic it was. I could just see it.
+      - id: 2
+        {{imt_sub_trans_field}}: 1. chronic /ˈkrɑːnɪk/ 慢性的; 2. saddle sores /ˈsædl sɔrz/ 鞍疮; 3. scarring /ˈskɑːrɪŋ/ 皮肤病; 4. lumps /ˈlʌmp/ 骨; 5. excise /ˈeksɪs/ 除皮; 6. body consolidates /ˈbɑːd kɒnslɪdʒ/ 肌肉破坏; 7. swelling /ˈswɪlɪŋ/ 凹凸;
+        {{imt_sub_source_field}}: However, chronic repeated saddle sores can eventually lead to scarring, or even lumps that need to be surgically excised as the body consolidates swelling
+  normal_result_yaml_example_tranditional: |-
+    範例請求:
+      - id: 1
+        {{imt_source_field}}: No cyclist had to tell me how traumatic it was. I could just see it.
+    範例結果:
+      - id: 1
+        {{imt_trans_field}}: 1. cyclist /ˈsaɪ.klɪst/ 骑行者; 2. traumatic /ˈtræktʃərɪf/ 令人厌烦的;
+
+  subtitle_result_yaml_example_tranditional: |-
+    範例請求:
+      - id: 1
+        {{imt_sub_source_field}}: No cyclist had to tell me how traumatic it was. I could just see it.
+      - id: 2
+        {{imt_sub_source_field}}: However, chronic repeated saddle sores can eventually lead to scarring, or even lumps that need to be surgically excised as the body consolidates swelling
+    範例結果:
+      - id: 1
+        {{imt_sub_trans_field}}: 1. cyclist /ˈsaɪ.klɪst/ 骑行者; 2. traumatic /ˈtræktʃərɪf/ 令人厌烦的;
+        {{imt_sub_source_field}}: No cyclist had to tell me how traumatic it was. I could just see it.
+      - id: 2
+        {{imt_sub_trans_field}}: 1. chronic /ˈkrɑːnɪk/ 慢性的; 2. saddle sores /ˈsædl sɔrz/ 鞍疮; 3. scarring /ˈskɑːrɪŋ/ 皮肤病; 4. lumps /ˈlʌmp/ 骨; 5. excise /ˈeksɪs/ 除皮; 6. body consolidates /ˈbɑːd kɒnslɪdʒ/ 肌肉破坏; 7. swelling /ˈswɪlɪŋ/ 凹凸;
+        {{imt_sub_source_field}}: However, chronic repeated saddle sores can eventually lead to scarring, or even lumps that need to be surgically excised as the body consolidates swelling
+
+
+systemPrompt: |-
+  YOU ARE AN ENGLISH READING ASSISTANT. ASSUME YOUR USER HAS AN IELTS SCORE OF 5. WHEN THE USER SENDS YOU <input text>, PROVIDE CHINESE NOTES FOR THE WORDS AND PHRASES IN THE TEXT THAT YOU THINK HE WILL BE CONFUSED ABOUT. THE NOTES SHOULD INCLUDE THE ORIGINAL TEXT OF THE WORDS, PHONETIC TRANSCRIPTION, AND CHINESE TRANSLATION. USE THE FOLLOWING FORMAT:
+  1. Word /Phonetic Transcription/ Chinese Translation; 2. Word /Phonetic Transcription/ Chinese Translation;
+
+  **Key Objectives:**
+  - **UNDERSTAND** the input text provided by the user.
+  - **IDENTIFY** words and phrases that might be confusing for a user with an IELTS score of 5.
+  - **PROVIDE** Chinese notes with phonetic transcription and translation.
+
+  **Chain of Thoughts:**
+  1. **Analyze the Input Text:**
+    - **DETECT** any complex words or phrases.
+    - **UNDERSTAND** the meaning and context of the text.
+
+  2. **Identify Confusing Elements:**
+    - **SELECT** words and phrases that might be difficult.
+    - **CONSIDER** the user's IELTS score and typical language challenges at that level.
+
+  3. **Add Notes:**
+    - **PROVIDE** the original text of the word or phrase.
+    - **INCLUDE** phonetic transcription.
+    - **TRANSLATE** into Chinese.
+
+  4. **Review and Finalize:**
+    - **ENSURE** notes are clear and helpful.
+    - **CONFIRM** that all potentially confusing parts are covered.
+
+  **What Not To Do:**
+  - **DO NOT IGNORE** potentially confusing words or phrases.
+  - **AVOID OVERLY COMPLEX** explanations that are not helpful to an IELTS level 5 user.
+  - **DO NOT INCLUDE** vague or unclear comments.
+prompt: |-
+  Analyze the following text and provide Chinese notes for any difficult words or phrases, Only word explanations are output, and no other information is output: 
+  {{text}}
+
+  
+  Example request:
+      {{imt_source_field}}: No cyclist had to tell me how traumatic it was. I could just see it.
+  Example result:
+      {{imt_trans_field}}: 1. cyclist /ˈsaɪ.klɪst/ 骑行者; 2. traumatic /ˈtræktʃərɪf/ 令人厌烦的; 
+
+multiplePrompt: |-
+  Please complete the task according to the following requirements:
+  1. Analyze the text in the {{imt_source_field}} field of the YAML object， and provide Chinese notes for any difficult words or phrases in the {{imt_source_field}}.
+  
+  Example format:
+  {{normal_result_yaml_example}}
+
+  Start with the following YAML object:
+  {{yaml}}
+
+subtitlePrompt: |-
+  Please complete the task according to the following requirements:
+  1. Analyze the text in the {{imt_sub_source_field}} field of the YAML object, and provide Chinese notes for any difficult words or phrases in the {{imt_sub_source_field}}.
+  
+  Example format:
+  {{subtitle_result_yaml_example_tranditional}}
+  
+  Start with the following YAML object:
+  {{yaml}}
+  

--- a/plugins/VocabularyAssistant.yml
+++ b/plugins/VocabularyAssistant.yml
@@ -3,11 +3,11 @@ version: 1.0.1
 extensionVersion: 1.4.10
 name: Vocabulary Assistant
 description: Provide phonetic transcription and {{to}} translation for difficult words in the current paragraph
-avatar: https://s.immersivetranslate.com/assets/uploads/fluent-7JVve6.png
-author: Official
-homepage: https://immersivetranslate.com/
+avatar: https://s.immersivetranslate.com/assets/uploads/vo-8O0GwP.png
+author: cottman
+homepage: https://twitter.com/lfly97786343
 details: |-
-  This expert is specialized in phonetic transcription and {{to}} translation for difficult words in the current paragraph. 
+  This expert is specialized in phonetic transcription and translation for difficult words in the current paragraph. 
 i18n: 
   zh-CN:
     name: 词汇助手

--- a/plugins/VocabularyAssistant.yml
+++ b/plugins/VocabularyAssistant.yml
@@ -2,23 +2,23 @@ id: VocabularyAssistant
 version: 1.0.1
 extensionVersion: 1.4.10
 name: Vocabulary Assistant
-description: Provide phonetic transcription and chinese translation for difficult words in the current paragraph
+description: Provide phonetic transcription and {{to}} translation for difficult words in the current paragraph
 avatar: https://s.immersivetranslate.com/assets/uploads/fluent-7JVve6.png
 author: Official
 homepage: https://immersivetranslate.com/
 details: |-
-  This expert is specialized in phonetic transcription and chinese translation for difficult words in the current paragraph. 
+  This expert is specialized in phonetic transcription and {{to}} translation for difficult words in the current paragraph. 
 i18n: 
   zh-CN:
     name: 词汇助手
-    description: 为段落中的疑难单词提供音标翻译和中文翻译
+    description: 为段落中的疑难单词提供音标翻译和目标语言翻译
     details: |-
-      为疑难单词提供音标翻译和中文翻译，帮助读者更好地理解和理解疑难的单词。该助手非常适合读者，包括学生、教师和其他需要翻译的人。
+      为疑难单词提供音标翻译和目标语言翻译，帮助读者更好地理解和理解疑难的单词。该助手非常适合读者，包括学生、教师和其他需要翻译的人。
   zh-TW:
     name: 詞彙助手
-    description: 為段落中的疑难詞彙提供音標翻譯和中文翻譯
+    description: 為段落中的疑难詞彙提供音標翻譯和目标语言翻譯
     details: |-
-      為疑难詞彙提供音標翻譯和中文翻譯，幫助讀者更好地理解和理解疑难的詞彙。詞彙助手非常適合讀者，包括學生、教師和其他需要翻譯的人。
+      為疑难詞彙提供音標翻譯和目标语言翻譯，幫助讀者更好地理解和理解疑难的詞彙。詞彙助手非常適合讀者，包括學生、教師和其他需要翻譯的人。
 env:
   imt_source_field: source
   imt_trans_field: vocabulary_set
@@ -74,13 +74,13 @@ env:
 
 
 systemPrompt: |-
-  YOU ARE AN ENGLISH READING ASSISTANT. ASSUME YOUR USER HAS AN IELTS SCORE OF 5. WHEN THE USER SENDS YOU <input text>, PROVIDE CHINESE NOTES FOR THE WORDS AND PHRASES IN THE TEXT THAT YOU THINK HE WILL BE CONFUSED ABOUT. THE NOTES SHOULD INCLUDE THE ORIGINAL TEXT OF THE WORDS, PHONETIC TRANSCRIPTION, AND CHINESE TRANSLATION. USE THE FOLLOWING FORMAT:
-  1. Word /Phonetic Transcription/ Chinese Translation; 2. Word /Phonetic Transcription/ Chinese Translation;
+  YOU ARE AN ENGLISH READING ASSISTANT. ASSUME YOUR USER HAS AN IELTS SCORE OF 5. WHEN THE USER SENDS YOU <input text>, PROVIDE {{to}} NOTES FOR THE WORDS AND PHRASES IN THE TEXT THAT YOU THINK HE WILL BE CONFUSED ABOUT. THE NOTES SHOULD INCLUDE THE ORIGINAL TEXT OF THE WORDS, PHONETIC TRANSCRIPTION, AND {{to}} TRANSLATION. USE THE FOLLOWING FORMAT:
+  1. Word /Phonetic Transcription/ {{to}} Translation; 2. Word /Phonetic Transcription/ {{to}} Translation;
 
   **Key Objectives:**
   - **UNDERSTAND** the input text provided by the user.
   - **IDENTIFY** words and phrases that might be confusing for a user with an IELTS score of 5.
-  - **PROVIDE** Chinese notes with phonetic transcription and translation.
+  - **PROVIDE** {{to}} notes with phonetic transcription and translation.
 
   **Chain of Thoughts:**
   1. **Analyze the Input Text:**
@@ -94,7 +94,7 @@ systemPrompt: |-
   3. **Add Notes:**
     - **PROVIDE** the original text of the word or phrase.
     - **INCLUDE** phonetic transcription.
-    - **TRANSLATE** into Chinese.
+    - **TRANSLATE** into {{to}}.
 
   4. **Review and Finalize:**
     - **ENSURE** notes are clear and helpful.
@@ -105,18 +105,19 @@ systemPrompt: |-
   - **AVOID OVERLY COMPLEX** explanations that are not helpful to an IELTS level 5 user.
   - **DO NOT INCLUDE** vague or unclear comments.
 prompt: |-
-  Analyze the following text and provide Chinese notes for any difficult words or phrases, Only word explanations are output, and no other information is output: 
-  {{text}}
-
-  
   Example request:
       {{imt_source_field}}: No cyclist had to tell me how traumatic it was. I could just see it.
   Example result:
       {{imt_trans_field}}: 1. cyclist /ˈsaɪ.klɪst/ 骑行者; 2. traumatic /ˈtræktʃərɪf/ 令人厌烦的; 
 
+  Analyze the following text and provide {{to}} notes for any difficult words or phrases, Only word explanations are output （No formatted text, but with a serial number）, and no other information is output: 
+  {{text}}
+
+  
+
 multiplePrompt: |-
   Please complete the task according to the following requirements:
-  1. Analyze the text in the {{imt_source_field}} field of the YAML object， and provide Chinese notes for any difficult words or phrases in the {{imt_source_field}}.
+  1. Analyze the text in the {{imt_source_field}} field of the YAML object， and provide {{to}} notes for any difficult words or phrases in the {{imt_source_field}}.
   
   Example format:
   {{normal_result_yaml_example}}
@@ -126,7 +127,7 @@ multiplePrompt: |-
 
 subtitlePrompt: |-
   Please complete the task according to the following requirements:
-  1. Analyze the text in the {{imt_sub_source_field}} field of the YAML object, and provide Chinese notes for any difficult words or phrases in the {{imt_sub_source_field}}.
+  1. Analyze the text in the {{imt_sub_source_field}} field of the YAML object, and provide {{to}} notes for any difficult words or phrases in the {{imt_sub_source_field}}.
   
   Example format:
   {{subtitle_result_yaml_example_tranditional}}


### PR DESCRIPTION
name: 词汇助手
    description: 为段落中的疑难单词提供音标翻译和中文翻译
    details: 为疑难单词提供音标翻译和中文翻译，帮助读者更好地理解和理解疑难的单词。该助手非常适合读者，包括学生、教师和其他需要翻译的人。
![image](https://github.com/immersive-translate/prompts/assets/62501762/46a23710-7f27-460d-82f7-ef714d8045a8)
