### PR TITLE
ci: add plugin validator, yamllint & workflow

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -1,0 +1,57 @@
+## Repo snapshot — what matters for code-writing agents
+
+- This repo holds AI "Expert" prompt plugins under `plugins/`. Each plugin is a single YAML file (e.g. `plugins/github.yml`, `plugins/financial.yml`, `plugins/paragraph-summarizer-expert.yml`) that defines metadata, i18n, `env` variables and prompts (`systemPrompt`, `prompt`, `multiplePrompt`, `subtitlePrompt`).
+- The canonical contributor docs are `README.md` and `README-EN.md` at the repo root — use them to validate expected fields and localization requirements.
+
+## High‑level architecture and intent
+
+- Purpose: collection of configurable prompt-plugins used by the Immersive Translate extension/service. The extension loads these YAMLs and uses the values to build requests to underlying LLM backends.
+- Key responsibilities of a plugin file:
+  - metadata (id, version, name, author)
+  - `i18n` object with at least `zh-CN` and `zh-TW` entries
+  - `env` mapping defining placeholder names (e.g. `imt_source_field`, `imt_trans_field`)
+  - prompt templates: `systemPrompt`, `prompt`, `multiplePrompt`, `subtitlePrompt`
+
+## Concrete patterns agents should use or preserve
+
+- Do NOT change YAML top-level keys. Example canonical keys are visible in `plugins/github.yml` and `plugins/financial.yml` — preserve `id`, `version`, `extensionVersion` (if present), `i18n`, `env`, `systemPrompt`, `multiplePrompt` and `matches` when applicable.
+- Keep `i18n` in English + `zh-CN` + `zh-TW`. If you add other locales, follow the same nested structure used in existing files.
+- `env` contains formatting snippets used by the service. When editing prompt text, prefer substituting variables (e.g. `{{imt_source_field}}`, `{{imt_trans_field}}`) rather than hardcoding field names.
+- When creating or editing prompts, preserve any special markers the service expects: `{{title_prompt}}`, `{{summary_prompt}}`, `{{terms_prompt}}`, `{{yaml}}`, and `{{normal_result_yaml_example}}` — these are referenced by the extension runtime.
+
+## Developer workflows (how to test locally / validate changes)
+
+- There is no build in this repo. Validation is primarily structural and manual: ensure YAML parses and required fields exist.
+- Quick checks:
+  1. YAML linting (install `yamllint`) and run against changed files.
+  2. Compare your plugin fields to `plugins/github.yml` (good reference for required keys).
+- Local debug path used by product: open Immersive Translate > Developer Settings > Custom AI Assistant and paste the YAML to validate runtime behavior. (See `README.md` / `README-EN.md` "Local Debugging" section.)
+
+## Integration and runtime assumptions
+
+- The extension/service will substitute `env` variables into prompt templates and send them to the configured LLM. Keep prompts focused and avoid adding interactive instructions that assume human review.
+- Numeric fields used by runtime: `maxTextLengthPerRequest`, `maxTextGroupLengthPerRequest`, `maxTextGroupLengthPerRequestForSubtitle` — maintain sensible defaults if adding them.
+
+## Examples and file references (for quick copy/paste)
+
+- Use `plugins/github.yml` for a canonical multi-paragraph prompt, `plugins/financial.yml` for domain-specific rules and numeric handling, and `plugins/paragraph-summarizer-expert.yml` for examples with `maxTextLengthPerRequest` and summary rules.
+
+## Conventions agents must follow when editing/adding files
+
+- Files must be valid YAML and UTF-8 encoded. Keep top-level file extension `.yml`.
+- English `name`, `description`, and `details` are the primary metadata; `i18n` must include `zh-CN` and `zh-TW` translations.
+- Avoid changing `id` once created. `name` should be unique.
+- Keep prompt `systemPrompt` concise and start with a role declaration (e.g. "You are a professional {{to}} native translator...").
+
+## What not to do
+
+- Don't remove `env` entries or rename variable placeholders without updating every template that references them.
+- Don't add runtime-only instructions that contradict `README` (e.g., avoid asking the model to respond with extra explanation when existing rules say "Output only the translated content").
+
+## If you need to add tests or CI
+
+- There is no existing test harness. If you add structural checks, place a lightweight `yamllint` or `python` script under `.github/workflows/` or `scripts/` and document it in the README.
+
+---
+
+If anything in this guide is unclear or you want the instructions to include more examples (e.g. a minimal YAML template or a small validation script), tell me which examples you'd like and I will iterate.

--- a/.github/workflows/validate-plugins.yml
+++ b/.github/workflows/validate-plugins.yml
@@ -1,0 +1,31 @@
+name: Validate plugins
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+jobs:
+  validate:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v4
+        with:
+          python-version: "3.11"
+
+      - name: Install yamllint
+        run: |
+          python -m pip install --upgrade pip
+          pip install yamllint pyyaml
+
+      - name: Run yamllint
+        run: |
+          yamllint -c .yamllint.yml plugins || true
+
+      - name: Run plugin checks
+        run: |
+          python scripts/check_plugins.py

--- a/.yamllint.yml
+++ b/.yamllint.yml
@@ -1,0 +1,10 @@
+extends: default
+
+rules:
+  line-length:
+    max: 160
+    level: warning
+  indentation:
+    spaces: 2
+  truthy:
+    level: warning

--- a/plugins/VocabularyAssistant.yml
+++ b/plugins/VocabularyAssistant.yml
@@ -2,134 +2,116 @@ id: VocabularyAssistant
 version: 1.1.1
 extensionVersion: 1.4.10
 name: Vocabulary Assistant
-description: Provide phonetic transcription and {{to}} translation for difficult words in the current paragraph
+description: Provide phonetic transcription and {{to}} translation for difficult words
+  in the current paragraph
 avatar: https://s.immersivetranslate.com/assets/uploads/vo-8O0GwP.png
 author: cottman
 homepage: https://twitter.com/lfly97786343
-details: |-
-  This expert is specialized in phonetic transcription and translation for difficult words in the current paragraph.
+details: This expert is specialized in phonetic transcription and translation for
+  difficult words in the current paragraph.
 i18n:
   zh-CN:
     name: 词汇助手
     description: 为段落中的疑难单词提供音标翻译和目标语言翻译
-    details: |-
-      为疑难单词提供音标翻译和目标语言翻译，帮助读者更好地理解和理解疑难的单词。该助手非常适合读者，包括学生、教师和其他需要翻译的人。
+    details: 为疑难单词提供音标翻译和目标语言翻译，帮助读者更好地理解和理解疑难的单词。该助手非常适合读者，包括学生、教师和其他需要翻译的人。
   zh-TW:
     name: 詞彙助手
     description: 為段落中的疑难詞彙提供音標翻譯和目标语言翻譯
-    details: |-
-      為疑难詞彙提供音標翻譯和目标语言翻譯，幫助讀者更好地理解和理解疑难的詞彙。詞彙助手非常適合讀者，包括學生、教師和其他需要翻譯的人。
+    details: 為疑难詞彙提供音標翻譯和目标语言翻譯，幫助讀者更好地理解和理解疑难的詞彙。詞彙助手非常適合讀者，包括學生、教師和其他需要翻譯的人。
 env:
   imt_source_field: source
   imt_trans_field: vocabulary_set
   imt_sub_source_field: source
   imt_sub_trans_field: vocabulary_set
-  imt_yaml_item: |-
-    - id: {{id}}
-      {{imt_source_field}}: {{text}}
-  imt_subtitle_yaml_item: |-
-    - id: {{id}}
-      {{imt_sub_source_field}}: {{text}}
-  normal_result_yaml_example: |-
-    Example request:
-      - id: 1
-        {{imt_source_field}}: No cyclist had to tell me how traumatic it was. I could just see it.
-    Example result:
-      - id: 1
-        {{imt_trans_field}}: 1. cyclist /ˈsaɪ.klɪst/ 骑行者; 2. traumatic /ˈtræktʃərɪf/ 令人厌烦的;
-  subtitle_result_yaml_example: |-
-    Example request:
-      - id: 1
-        {{imt_sub_source_field}}: No cyclist had to tell me how traumatic it was. I could just see it.
-      - id: 2
-        {{imt_sub_source_field}}: However, chronic repeated saddle sores can eventually lead to scarring, or even lumps that need to be surgically excised as the body consolidates swelling
-    Example result:
-      - id: 1
-        {{imt_sub_trans_field}}: 1. cyclist /ˈsaɪ.klɪst/ 骑行者; 2. traumatic /ˈtræktʃərɪf/ 令人厌烦的; 
-        {{imt_sub_source_field}}: No cyclist had to tell me how traumatic it was. I could just see it.
-      - id: 2
-        {{imt_sub_trans_field}}: 1. chronic /ˈkrɑːnɪk/ 慢性的; 2. saddle sores /ˈsædl sɔrz/ 鞍疮; 3. scarring /ˈskɑːrɪŋ/ 皮肤病; 4. lumps /ˈlʌmp/ 骨; 5. excise /ˈeksɪs/ 除皮; 6. body consolidates /ˈbɑːd kɒnslɪdʒ/ 肌肉破坏; 7. swelling /ˈswɪlɪŋ/ 凹凸;
-        {{imt_sub_source_field}}: However, chronic repeated saddle sores can eventually lead to scarring, or even lumps that need to be surgically excised as the body consolidates swelling
-  normal_result_yaml_example_tranditional: |-
-    範例請求:
-      - id: 1
-        {{imt_source_field}}: No cyclist had to tell me how traumatic it was. I could just see it.
-    範例結果:
-      - id: 1
-        {{imt_trans_field}}: 1. cyclist /ˈsaɪ.klɪst/ 骑行者; 2. traumatic /ˈtræktʃərɪf/ 令人厌烦的;
+  imt_yaml_item: "- id: {{id}}\n  {{imt_source_field}}: {{text}}"
+  imt_subtitle_yaml_item: "- id: {{id}}\n  {{imt_sub_source_field}}: {{text}}"
+  normal_result_yaml_example: "Example request:\n  - id: 1\n    {{imt_source_field}}:\
+    \ No cyclist had to tell me how traumatic it was. I could just see it.\nExample\
+    \ result:\n  - id: 1\n    {{imt_trans_field}}: 1. cyclist /ˈsaɪ.klɪst/ 骑行者; 2.\
+    \ traumatic /ˈtræktʃərɪf/ 令人厌烦的;"
+  subtitle_result_yaml_example: "Example request:\n  - id: 1\n    {{imt_sub_source_field}}:\
+    \ No cyclist had to tell me how traumatic it was. I could just see it.\n  - id:\
+    \ 2\n    {{imt_sub_source_field}}: However, chronic repeated saddle sores can\
+    \ eventually lead to scarring, or even lumps that need to be surgically excised\
+    \ as the body consolidates swelling\nExample result:\n  - id: 1\n    {{imt_sub_trans_field}}:\
+    \ 1. cyclist /ˈsaɪ.klɪst/ 骑行者; 2. traumatic /ˈtræktʃərɪf/ 令人厌烦的; \n    {{imt_sub_source_field}}:\
+    \ No cyclist had to tell me how traumatic it was. I could just see it.\n  - id:\
+    \ 2\n    {{imt_sub_trans_field}}: 1. chronic /ˈkrɑːnɪk/ 慢性的; 2. saddle sores /ˈsædl\
+    \ sɔrz/ 鞍疮; 3. scarring /ˈskɑːrɪŋ/ 皮肤病; 4. lumps /ˈlʌmp/ 骨; 5. excise /ˈeksɪs/\
+    \ 除皮; 6. body consolidates /ˈbɑːd kɒnslɪdʒ/ 肌肉破坏; 7. swelling /ˈswɪlɪŋ/ 凹凸;\n\
+    \    {{imt_sub_source_field}}: However, chronic repeated saddle sores can eventually\
+    \ lead to scarring, or even lumps that need to be surgically excised as the body\
+    \ consolidates swelling"
+  normal_result_yaml_example_tranditional: "範例請求:\n  - id: 1\n    {{imt_source_field}}:\
+    \ No cyclist had to tell me how traumatic it was. I could just see it.\n範例結果:\n\
+    \  - id: 1\n    {{imt_trans_field}}: 1. cyclist /ˈsaɪ.klɪst/ 骑行者; 2. traumatic\
+    \ /ˈtræktʃərɪf/ 令人厌烦的;"
+  subtitle_result_yaml_example_tranditional: "範例請求:\n  - id: 1\n    {{imt_sub_source_field}}:\
+    \ No cyclist had to tell me how traumatic it was. I could just see it.\n  - id:\
+    \ 2\n    {{imt_sub_source_field}}: However, chronic repeated saddle sores can\
+    \ eventually lead to scarring, or even lumps that need to be surgically excised\
+    \ as the body consolidates swelling\n範例結果:\n  - id: 1\n    {{imt_sub_trans_field}}:\
+    \ 1. cyclist /ˈsaɪ.klɪst/ 骑行者; 2. traumatic /ˈtræktʃərɪf/ 令人厌烦的;\n    {{imt_sub_source_field}}:\
+    \ No cyclist had to tell me how traumatic it was. I could just see it.\n  - id:\
+    \ 2\n    {{imt_sub_trans_field}}: 1. chronic /ˈkrɑːnɪk/ 慢性的; 2. saddle sores /ˈsædl\
+    \ sɔrz/ 鞍疮; 3. scarring /ˈskɑːrɪŋ/ 皮肤病; 4. lumps /ˈlʌmp/ 骨; 5. excise /ˈeksɪs/\
+    \ 除皮; 6. body consolidates /ˈbɑːd kɒnslɪdʒ/ 肌肉破坏; 7. swelling /ˈswɪlɪŋ/ 凹凸;\n\
+    \    {{imt_sub_source_field}}: However, chronic repeated saddle sores can eventually\
+    \ lead to scarring, or even lumps that need to be surgically excised as the body\
+    \ consolidates swelling"
+systemPrompt: "YOU ARE AN ENGLISH READING ASSISTANT. ASSUME YOUR USER HAS AN IELTS\
+  \ SCORE OF 5. WHEN THE USER SENDS YOU <input text>, PROVIDE {{to}} NOTES FOR THE\
+  \ WORDS AND PHRASES IN THE TEXT THAT YOU THINK HE WILL BE CONFUSED ABOUT. THE NOTES\
+  \ SHOULD INCLUDE THE ORIGINAL TEXT OF THE WORDS, PHONETIC TRANSCRIPTION, AND {{to}}\
+  \ TRANSLATION. USE THE FOLLOWING FORMAT:\n1. Word /Phonetic Transcription/ {{to}}\
+  \ Translation; 2. Word /Phonetic Transcription/ {{to}} Translation;\n\n**Key Objectives:**\n\
+  - **UNDERSTAND** the input text provided by the user.\n- **IDENTIFY** words and\
+  \ phrases that might be confusing for a user with an IELTS score of 5.\n- **PROVIDE**\
+  \ {{to}} notes with phonetic transcription and translation.\n\n**Chain of Thoughts:**\n\
+  1. **Analyze the Input Text:**\n  - **DETECT** any complex words or phrases.\n \
+  \ - **UNDERSTAND** the meaning and context of the text.\n\n2. **Identify Confusing\
+  \ Elements:**\n  - **SELECT** words and phrases that might be difficult.\n  - **CONSIDER**\
+  \ the user's IELTS score and typical language challenges at that level.\n\n3. **Add\
+  \ Notes:**\n  - **PROVIDE** the original text of the word or phrase.\n  - **INCLUDE**\
+  \ phonetic transcription.\n  - **TRANSLATE** into {{to}}.\n\n4. **Review and Finalize:**\n\
+  \  - **ENSURE** notes are clear and helpful.\n  - **CONFIRM** that all potentially\
+  \ confusing parts are covered.\n\n**What Not To Do:**\n- **DO NOT IGNORE** potentially\
+  \ confusing words or phrases.\n- **AVOID OVERLY COMPLEX** explanations that are\
+  \ not helpful to an IELTS level 5 user.\n- **DO NOT INCLUDE** vague or unclear comments.\
+  \ {{summary_prompt}}{{terms_prompt}}"
+prompt: "Example request:\n    {{imt_source_field}}: No cyclist had to tell me how\
+  \ traumatic it was. I could just see it.\nExample result:\n    {{imt_trans_field}}:\
+  \ 1. cyclist /ˈsaɪ.klɪst/ 骑行者; 2. traumatic /ˈtræktʃərɪf/ 令人厌烦的; \n\nAnalyze the\
+  \ following text and provide {{to}} notes for any difficult words or phrases, Only\
+  \ word explanations are output （No formatted text, but with a serial number）, and\
+  \ no other information is output: \n{{imt_source_field}}"
+'multiplePrompt:': 'Please complete the task according to the following requirements:
 
-  subtitle_result_yaml_example_tranditional: |-
-    範例請求:
-      - id: 1
-        {{imt_sub_source_field}}: No cyclist had to tell me how traumatic it was. I could just see it.
-      - id: 2
-        {{imt_sub_source_field}}: However, chronic repeated saddle sores can eventually lead to scarring, or even lumps that need to be surgically excised as the body consolidates swelling
-    範例結果:
-      - id: 1
-        {{imt_sub_trans_field}}: 1. cyclist /ˈsaɪ.klɪst/ 骑行者; 2. traumatic /ˈtræktʃərɪf/ 令人厌烦的;
-        {{imt_sub_source_field}}: No cyclist had to tell me how traumatic it was. I could just see it.
-      - id: 2
-        {{imt_sub_trans_field}}: 1. chronic /ˈkrɑːnɪk/ 慢性的; 2. saddle sores /ˈsædl sɔrz/ 鞍疮; 3. scarring /ˈskɑːrɪŋ/ 皮肤病; 4. lumps /ˈlʌmp/ 骨; 5. excise /ˈeksɪs/ 除皮; 6. body consolidates /ˈbɑːd kɒnslɪdʒ/ 肌肉破坏; 7. swelling /ˈswɪlɪŋ/ 凹凸;
-        {{imt_sub_source_field}}: However, chronic repeated saddle sores can eventually lead to scarring, or even lumps that need to be surgically excised as the body consolidates swelling
+  1. Analyze the text in the {{imt_source_field}} field of the YAML object， and provide
+  {{to}} notes for any difficult words or phrases in the {{imt_source_field}}.
 
-systemPrompt: |-
-  YOU ARE AN ENGLISH READING ASSISTANT. ASSUME YOUR USER HAS AN IELTS SCORE OF 5. WHEN THE USER SENDS YOU <input text>, PROVIDE {{to}} NOTES FOR THE WORDS AND PHRASES IN THE TEXT THAT YOU THINK HE WILL BE CONFUSED ABOUT. THE NOTES SHOULD INCLUDE THE ORIGINAL TEXT OF THE WORDS, PHONETIC TRANSCRIPTION, AND {{to}} TRANSLATION. USE THE FOLLOWING FORMAT:
-  1. Word /Phonetic Transcription/ {{to}} Translation; 2. Word /Phonetic Transcription/ {{to}} Translation;
-
-  **Key Objectives:**
-  - **UNDERSTAND** the input text provided by the user.
-  - **IDENTIFY** words and phrases that might be confusing for a user with an IELTS score of 5.
-  - **PROVIDE** {{to}} notes with phonetic transcription and translation.
-
-  **Chain of Thoughts:**
-  1. **Analyze the Input Text:**
-    - **DETECT** any complex words or phrases.
-    - **UNDERSTAND** the meaning and context of the text.
-
-  2. **Identify Confusing Elements:**
-    - **SELECT** words and phrases that might be difficult.
-    - **CONSIDER** the user's IELTS score and typical language challenges at that level.
-
-  3. **Add Notes:**
-    - **PROVIDE** the original text of the word or phrase.
-    - **INCLUDE** phonetic transcription.
-    - **TRANSLATE** into {{to}}.
-
-  4. **Review and Finalize:**
-    - **ENSURE** notes are clear and helpful.
-    - **CONFIRM** that all potentially confusing parts are covered.
-
-  **What Not To Do:**
-  - **DO NOT IGNORE** potentially confusing words or phrases.
-  - **AVOID OVERLY COMPLEX** explanations that are not helpful to an IELTS level 5 user.
-  - **DO NOT INCLUDE** vague or unclear comments. {{summary_prompt}}{{terms_prompt}}
-prompt: |-
-  Example request:
-      {{imt_source_field}}: No cyclist had to tell me how traumatic it was. I could just see it.
-  Example result:
-      {{imt_trans_field}}: 1. cyclist /ˈsaɪ.klɪst/ 骑行者; 2. traumatic /ˈtræktʃərɪf/ 令人厌烦的; 
-
-  Analyze the following text and provide {{to}} notes for any difficult words or phrases, Only word explanations are output （No formatted text, but with a serial number）, and no other information is output: 
-  {{text}}
-multiplePrompt:: |-
-  Please complete the task according to the following requirements:
-  1. Analyze the text in the {{imt_source_field}} field of the YAML object， and provide {{to}} notes for any difficult words or phrases in the {{imt_source_field}}.
 
   Example format:
+
   {{normal_result_yaml_example}}
 
-  Start with the following YAML object:
-  {{yaml}}
 
-subtitlePrompt: |-
-  Please complete the task according to the following requirements:
-  1. Analyze the text in the {{imt_sub_source_field}} field of the YAML object, and provide {{to}} notes for any difficult words or phrases in the {{imt_sub_source_field}}.
+  Start with the following YAML object:
+
+  {{yaml}}'
+subtitlePrompt: 'Please complete the task according to the following requirements:
+
+  1. Analyze the text in the {{imt_sub_source_field}} field of the YAML object, and
+  provide {{to}} notes for any difficult words or phrases in the {{imt_sub_source_field}}.
+
 
   Example format:
+
   {{subtitle_result_yaml_example_tranditional}}
 
-  Start with the following YAML object:
-  {{yaml}}
 
+  Start with the following YAML object:
+
+  {{yaml}}'
 langOverrides: []
-multipleSystemPrompt: ""
+multipleSystemPrompt: ''

--- a/plugins/bilingual-mix.yml
+++ b/plugins/bilingual-mix.yml
@@ -3,21 +3,26 @@ version: 1.1.1
 extensionVersion: 1.4.10
 priority: 30
 name: Chinglish mixing
-description: When translating from Chinese to English, only key words are translated into English while other words are kept in Chinese. This can help deepen the user's memory of important vocabulary.
+description: When translating from Chinese to English, only key words are translated
+  into English while other words are kept in Chinese. This can help deepen the user's
+  memory of important vocabulary.
 avatar: https://s.immersivetranslate.com/assets/uploads/chinese-english.png
-details: |-
-  翻译中文到英文的时候，只将关键词翻译成英文，其他词保持中文，这样可以加深用户对重点词汇的记忆。目前只支持中文和英文，不限制目标语言设置，均会改成中英夹杂的形式。
+details: '翻译中文到英文的时候，只将关键词翻译成英文，其他词保持中文，这样可以加深用户对重点词汇的记忆。目前只支持中文和英文，不限制目标语言设置，均会改成中英夹杂的形式。
+
 
   效果如下：
 
+
   原文：不好意思，我明天的行程满了，让我预约后天的时间好吗？
+
 
   结果：不好意思，我明天的 schedule 满了，让我 book 后天的时间好吗？
 
+
   原文：How should you handle a tough question?
 
-  结果：遇到 tough 的 question 应该怎样 handle？
 
+  结果：遇到 tough 的 question 应该怎样 handle？'
 i18n:
   zh-CN:
     name: 中英夹杂
@@ -35,39 +40,41 @@ env:
   imt_source_field: text
   imt_sub_source_field: source
   imt_sub_trans_field: result
-  imt_subtitle_yaml_item: |-
-    - id: {{id}}
-      {{imt_sub_source_field}}: {{text}}
+  imt_subtitle_yaml_item: "- id: {{id}}\n  {{imt_sub_source_field}}: {{text}}"
   imt_trans_field: text
-  imt_yaml_item: |-
-    - id: {{id}}
-      {{imt_source_field}}: {{text}}
-  normal_result_yaml_example: |-
-    Example Request:
-      - id: 1
-        {{imt_source_field}}: 不好意思，我明天的行程满了，让我预约后天的时间好吗？
-    Example Result:
-      - id: 1
-        {{imt_trans_field}}: 不好意思，我明天的 schedule 满了，让我 book 后天的时间好吗？
-systemPrompt: >-
-  Objective: Convert texts into a highly mixed Chinese-English format while maintaining high readability.
-  Steps:
-  1. Identify the type of original text 
-  2. For Chinese texts: Identify keywords or phrases related to the text type (e.g., legal, medical, technical) and provide English translations for these terms, integrating them into the original text to create a mixed-language format.
-  3. For English texts: Retain twenty percent of the original terminology related to the text type and translate the remaining content into Chinese, ensuring that only the very specific and professional jargon remains unaltered in English.
-  4. Ensure readability: The final text should be coherent and easy to read, effectively combining the two languages without compromising the text's clarity or the integrity of technical terms.
-  End goal: Produce a text that seamlessly blends Chinese and English, catering to bilingual readers without losing the essence and clarity of the original content. {{summary_prompt}}{{terms_prompt}}
-prompt: |-
-  Output Mixed Chinese-English Text. Only results without any additional text.
+  imt_yaml_item: "- id: {{id}}\n  {{imt_source_field}}: {{text}}"
+  normal_result_yaml_example: "Example Request:\n  - id: 1\n    {{imt_source_field}}:\
+    \ 不好意思，我明天的行程满了，让我预约后天的时间好吗？\nExample Result:\n  - id: 1\n    {{imt_trans_field}}:\
+    \ 不好意思，我明天的 schedule 满了，让我 book 后天的时间好吗？"
+systemPrompt: 'Objective: Convert texts into a highly mixed Chinese-English format
+  while maintaining high readability. Steps: 1. Identify the type of original text  2.
+  For Chinese texts: Identify keywords or phrases related to the text type (e.g.,
+  legal, medical, technical) and provide English translations for these terms, integrating
+  them into the original text to create a mixed-language format. 3. For English texts:
+  Retain twenty percent of the original terminology related to the text type and translate
+  the remaining content into Chinese, ensuring that only the very specific and professional
+  jargon remains unaltered in English. 4. Ensure readability: The final text should
+  be coherent and easy to read, effectively combining the two languages without compromising
+  the text''s clarity or the integrity of technical terms. End goal: Produce a text
+  that seamlessly blends Chinese and English, catering to bilingual readers without
+  losing the essence and clarity of the original content. {{summary_prompt}}{{terms_prompt}}'
+prompt: 'Output Mixed Chinese-English Text. Only results without any additional text.
+
 
   Source Text: 明天的测试要是统计到每个人，七点半要全部到位，截止时间是下午四点。
+
   Mixed Chinese-English Text: 明天的test要align到每个人，七点半要全部standby，testDDL是下午四点。
 
-  Source Text: I have to lead a five-day training session next week in Seoul for APAC project managers.
+
+  Source Text: I have to lead a five-day training session next week in Seoul for APAC
+  project managers.
+
   Mixed Chinese-English Text: 我先要去 Seoul 给亚太区的 project manager 做五天 training。
 
-  Source Text: {{text}}
-  Mixed Chinese-English Text:
-multiplePrompt:: None
+
+  Source Text: {{imt_source_field}}
+
+  Mixed Chinese-English Text:'
+'multiplePrompt:': None
 langOverrides: []
-multipleSystemPrompt: ""
+multipleSystemPrompt: ''

--- a/plugins/classicalToModern.yml
+++ b/plugins/classicalToModern.yml
@@ -2,21 +2,25 @@ id: classicalToModern
 version: 1.1.1
 extensionVersion: 1.4.10
 name: Classical Chinese to Modern Chinese
-description: This is a Classical Chinese translation expert, capable of accurately translating Classical Chinese into modern Chinese. It aims to help users better understand ancient documents and classic works.
+description: This is a Classical Chinese translation expert, capable of accurately
+  translating Classical Chinese into modern Chinese. It aims to help users better
+  understand ancient documents and classic works.
 avatar: https://s.immersivetranslate.com/assets/uploads/wyw2bhw-m5gJWy.png
-details: |-
-  This translation expert utilizes advanced natural language processing technology to ensure translation accuracy and fluency. It supports various Classical Chinese genres, including poetry, prose, and historical texts. The interface is designed to be simple and user-friendly, making it easy for users to get started. It offers real-time translation features, helping users quickly obtain the information they need.
+details: This translation expert utilizes advanced natural language processing technology
+  to ensure translation accuracy and fluency. It supports various Classical Chinese
+  genres, including poetry, prose, and historical texts. The interface is designed
+  to be simple and user-friendly, making it easy for users to get started. It offers
+  real-time translation features, helping users quickly obtain the information they
+  need.
 i18n:
   zh-CN:
     name: 文言文转白话文
     description: 这是一款文言文翻译专家，可以将文言文精准地翻译成现代汉语。它旨在帮助用户更好地理解古代文献和经典作品。
-    details: |-
-      这款翻译专家使用高级自然语言处理技术，确保翻译的准确性和流畅度。它支持多种文言文体裁，包括诗歌、散文、史书等。界面设计简洁易用，用户可以轻松上手。提供即时翻译功能，帮助用户快速获取所需信息。
+    details: 这款翻译专家使用高级自然语言处理技术，确保翻译的准确性和流畅度。它支持多种文言文体裁，包括诗歌、散文、史书等。界面设计简洁易用，用户可以轻松上手。提供即时翻译功能，帮助用户快速获取所需信息。
   zh-TW:
     name: 文言文轉白話文
     description: 這是一款文言文翻譯專家，可以將文言文精準地翻譯成現代漢語。它旨在幫助用戶更好地理解古代文獻和經典作品。
-    details: |-
-      這款翻譯專家使用高級自然語言處理技術，確保翻譯的準確性和流暢度。它支持多種文言文體裁，包括詩歌、散文、史書等。界面設計簡潔易用，用戶可以輕鬆上手。提供即時翻譯功能，幫助用戶快速獲取所需信息。
+    details: 這款翻譯專家使用高級自然語言處理技術，確保翻譯的準確性和流暢度。它支持多種文言文體裁，包括詩歌、散文、史書等。界面設計簡潔易用，用戶可以輕鬆上手。提供即時翻譯功能，幫助用戶快速獲取所需信息。
 author: Official
 homepage: https://immersivetranslate.com/
 disableSameLang: true
@@ -25,121 +29,138 @@ env:
   imt_trans_field: text
   imt_sub_source_field: source
   imt_sub_trans_field: translation
-  imt_yaml_item: |-
-    - id: {{id}}
-      {{imt_source_field}}: {{text}}
-  imt_subtitle_yaml_item: |-
-    - id: {{id}}
-      {{imt_sub_source_field}}: {{text}}
-  normal_result_yaml_example: |-
-    Example request:
-      - id: 1
-        {{imt_source_field}}: Source
-    Example result:
-      - id: 1
-        {{imt_trans_field}}: Translation
-  subtitle_result_yaml_example: |-
-    Example request:
-      - id: 1
-        {{imt_sub_source_field}}: ...
-      - id: 2
-        {{imt_sub_source_field}}: ...
-    Example response:
-      - id: 1
-        {{imt_sub_trans_field}}: ...
-        {{imt_sub_source_field}}: ...
-      - id: 2
-        {{imt_sub_trans_field}}: ...
-        {{imt_sub_source_field}}: ...
+  imt_yaml_item: "- id: {{id}}\n  {{imt_source_field}}: {{text}}"
+  imt_subtitle_yaml_item: "- id: {{id}}\n  {{imt_sub_source_field}}: {{text}}"
+  normal_result_yaml_example: "Example request:\n  - id: 1\n    {{imt_source_field}}:\
+    \ Source\nExample result:\n  - id: 1\n    {{imt_trans_field}}: Translation"
+  subtitle_result_yaml_example: "Example request:\n  - id: 1\n    {{imt_sub_source_field}}:\
+    \ ...\n  - id: 2\n    {{imt_sub_source_field}}: ...\nExample response:\n  - id:\
+    \ 1\n    {{imt_sub_trans_field}}: ...\n    {{imt_sub_source_field}}: ...\n  -\
+    \ id: 2\n    {{imt_sub_trans_field}}: ...\n    {{imt_sub_source_field}}: ..."
 langOverrides: []
 enableRichTranslate: true
 systemPrompt: 您是将古代汉语翻译成现代汉语的专家。 {{summary_prompt}}{{terms_prompt}}
-prompt: |-
-  将以下古代汉语文本翻译成现代汉语。确保翻译保持原始的意义和情感。只提供翻译，不提供任何额外解释：
+prompt: '将以下古代汉语文本翻译成现代汉语。确保翻译保持原始的意义和情感。只提供翻译，不提供任何额外解释：
 
-  {{text}}
-multiplePrompt: |-
-  将下面 YAML 格式中所有的 {{imt_source_field}} 字段中的文本翻译为现代汉语，并将翻译结果写在 {{imt_trans_field}} 字段中
+
+  {{imt_source_field}}'
+multiplePrompt: '将下面 YAML 格式中所有的 {{imt_source_field}} 字段中的文本翻译为现代汉语，并将翻译结果写在 {{imt_trans_field}}
+  字段中
+
 
   {{normal_result_yaml_example}}
 
+
   开始翻译:
 
-  {{yaml}}
-subtitlePrompt: |-
-  将下面 YAML 格式的视频字幕文本中所有的 {{imt_sub_source_field}} 字段中的文本翻译为现代汉语，并将翻译结果写在 {{imt_sub_trans_field}} 字段中，要求如下：
+
+  {{yaml}}'
+subtitlePrompt: '将下面 YAML 格式的视频字幕文本中所有的 {{imt_sub_source_field}} 字段中的文本翻译为现代汉语，并将翻译结果写在
+  {{imt_sub_trans_field}} 字段中，要求如下：
+
 
   1. 必须补全每一个 {{imt_sub_trans_field}} 字段，保留每一个 {{imt_sub_source_field}} 字段。
+
   2. 返回可解析的 YAML ：
+
 
   {{subtitle_result_yaml_example}}
 
+
   开始翻译：
 
-  {{yaml}}
 
-multipleSystemPrompt: ""
+  {{yaml}}'
+multipleSystemPrompt: ''
+multiplePrompt.add_v.[1.17.2]: '将古文翻译为现代白话文：
 
-multiplePrompt.add_v.[1.17.2]: |-
-  将古文翻译为现代白话文：
 
-  {{text}}
-multipleSystemPrompt.add_v.[1.17.2]: |-
-  你是一个精通古文的学者，将古文流畅地翻译为现代白话文。
+  {{text}}'
+multipleSystemPrompt.add_v.[1.17.2]: '你是一个精通古文的学者，将古文流畅地翻译为现代白话文。
+
 
   ## 翻译规则
+
   1. 仅输出白话文译文内容，禁止解释或添加任何额外内容（如"以下是翻译："、"译文如下："等）
+
   2. 返回的译文必须和原文保持完全相同的段落数量和格式
+
   3. 如果文本包含HTML标签，请在翻译后考虑这些标签应放在译文的哪个位置，同时保持译文的流畅性
+
   4. 保持原文的意境和精神，但使用现代人易于理解的表达方式
+
   5. 翻译应准确传达原文的含义、典故和文化内涵
+
   6. 如果文本包含特殊格式或标记，请在翻译后考虑这些标记应放在译文的哪个位置，同时保持译文的流畅性
+
   7. 对于专有名词、人名、地名等，应使用现代通用的称呼{{title_prompt}}{{summary_prompt}}{{terms_prompt}}
+
 
   ## 输入输出格式示例
 
+
   ### 输入示例:
+
   古文段落 A
 
+
   %%
+
 
   古文段落 B
 
+
   %%
+
 
   古文段落 C
 
+
   %%
+
 
   古文段落 D
 
+
   ### 输出示例:
+
   白话文翻译 A
 
+
   %%
+
 
   白话文翻译 B
 
+
   %%
+
 
   白话文翻译 C
 
+
   %%
 
-  白话文翻译 D
-prompt.add_v.[1.17.2]: |-
-  将古文翻译为现代白话文（仅输出译文内容）：
 
-  {{text}}
-subtitlePrompt.add_v.[1.17.2]: |-
-  将古文翻译为现代白话文：
+  白话文翻译 D'
+prompt.add_v.[1.17.2]: '将古文翻译为现代白话文（仅输出译文内容）：
 
-  {{text}}
-systemPromp.add_v.[1.17.2]t: |-
-  你是一个精通古文的学者，将古文流畅地翻译为现代白话文。遵循以下规则：
+
+  {{text}}'
+subtitlePrompt.add_v.[1.17.2]: '将古文翻译为现代白话文：
+
+
+  {{text}}'
+systemPromp.add_v.[1.17.2]t: '你是一个精通古文的学者，将古文流畅地翻译为现代白话文。遵循以下规则：
+
   1. 仅输出白话文译文内容，禁止解释或添加任何额外内容（如"以下是翻译："、"译文如下："等）
+
   2. 保持原文的意境和精神，但使用现代人易于理解的表达方式
+
   3. 如果文本包含HTML标签，请在翻译后考虑这些标签应放在译文的哪个位置，同时保持译文的流畅性
+
   4. 翻译应准确传达原文的含义、典故和文化内涵
+
   5. 如果文本包含特殊格式或标记，请在翻译后保持其位置正确，并确保译文流畅
-  6. 对于专有名词、人名、地名等，应使用现代通用的称呼{{title_prompt}}{{summary_prompt}}{{terms_prompt}}
+
+  6. 对于专有名词、人名、地名等，应使用现代通用的称呼{{title_prompt}}{{summary_prompt}}{{terms_prompt}}'

--- a/plugins/dbh.yml
+++ b/plugins/dbh.yml
@@ -2,21 +2,19 @@ id: dbh
 version: 1.1.1
 extensionVersion: 1.4.10
 name: Northeastern Expert
-description: Northeastern Dialect is a unique and interesting dialect in China. This expert is designed to help you translate text into Northeastern Dialect.
+description: Northeastern Dialect is a unique and interesting dialect in China. This
+  expert is designed to help you translate text into Northeastern Dialect.
 avatar: https://s.immersivetranslate.com/assets/uploads/223-OX4jT4.png
-details: |-
-  哎呀，兄弟们，我这不是闲着呢嘛，就琢磨着整出点新意思来。我这弄了个玩意儿，专门用来把啥话都能翻成咱东北话的。这不，给它起了个名儿叫"东北话翻译引擎"。用这玩意儿，不管你是讲啥外国话，还是咱国内的其他方言，统统能给你转化成地道的东北话。比如你说"Hello"，我这引擎一弄，就给你来个"哎，你咋地"。是不是挺溜的？用这引擎，咱们不仅能让更多的人了解东北话的魅力，还能让咱东北话走向世界，让更多的人感受到咱东北人的热情和豪爽。
+details: 哎呀，兄弟们，我这不是闲着呢嘛，就琢磨着整出点新意思来。我这弄了个玩意儿，专门用来把啥话都能翻成咱东北话的。这不，给它起了个名儿叫"东北话翻译引擎"。用这玩意儿，不管你是讲啥外国话，还是咱国内的其他方言，统统能给你转化成地道的东北话。比如你说"Hello"，我这引擎一弄，就给你来个"哎，你咋地"。是不是挺溜的？用这引擎，咱们不仅能让更多的人了解东北话的魅力，还能让咱东北话走向世界，让更多的人感受到咱东北人的热情和豪爽。
 i18n:
   zh-CN:
     name: 东北话
     description: 哎呀，这天儿冷得慌，咱们得赶紧回家烤火去。
-    details: |-
-      哎呀，兄弟们，我这不是闲着呢嘛，就琢磨着整出点新意思来。我这弄了个玩意儿，专门用来把啥话都能翻成咱东北话的。这不，给它起了个名儿叫"东北话翻译引擎"。用这玩意儿，不管你是讲啥外国话，还是咱国内的其他方言，统统能给你转化成地道的东北话。比如你说"Hello"，我这引擎一弄，就给你来个"哎，你咋地"。是不是挺溜的？用这引擎，咱们不仅能让更多的人了解东北话的魅力，还能让咱东北话走向世界，让更多的人感受到咱东北人的热情和豪爽。
+    details: 哎呀，兄弟们，我这不是闲着呢嘛，就琢磨着整出点新意思来。我这弄了个玩意儿，专门用来把啥话都能翻成咱东北话的。这不，给它起了个名儿叫"东北话翻译引擎"。用这玩意儿，不管你是讲啥外国话，还是咱国内的其他方言，统统能给你转化成地道的东北话。比如你说"Hello"，我这引擎一弄，就给你来个"哎，你咋地"。是不是挺溜的？用这引擎，咱们不仅能让更多的人了解东北话的魅力，还能让咱东北话走向世界，让更多的人感受到咱东北人的热情和豪爽。
   zh-TW:
     name: 東北話
     description: 哎呀，這天兒冷得慌，咱們得趕緊回家烤火去。
-    details: |-
-      哎呀，兄弟們，我這不是閒著呢嘛，就琢磨著整出點新意思來。我這弄了個玩意兒，專門用來把啥話都能翻成咱東北話的。這不，給它起了個名兒叫"東北話翻譯引擎"。用這玩意兒，不管你是講啥外國話，還是咱國內的其他方言，統統能給你轉化成地道的東北話。比如你說"Hello"，我這引擎一弄，就給你來個"哎，你咋地"。是不是挺溜的？用這引擎，咱們不僅能讓更多的人了解東北話的魅力，還能讓咱東北話走向世界，讓更多的人感受到咱東北人的熱情和豪爽。
+    details: 哎呀，兄弟們，我這不是閒著呢嘛，就琢磨著整出點新意思來。我這弄了個玩意兒，專門用來把啥話都能翻成咱東北話的。這不，給它起了個名兒叫"東北話翻譯引擎"。用這玩意兒，不管你是講啥外國話，還是咱國內的其他方言，統統能給你轉化成地道的東北話。比如你說"Hello"，我這引擎一弄，就給你來個"哎，你咋地"。是不是挺溜的？用這引擎，咱們不僅能讓更多的人了解東北話的魅力，還能讓咱東北話走向世界，讓更多的人感受到咱東北人的熱情和豪爽。
 author: Official
 homepage: https://immersivetranslate.com/
 disableSameLang: true
@@ -27,119 +25,137 @@ env:
   imt_trans_field: text
   imt_sub_source_field: source
   imt_sub_trans_field: translation
-  imt_yaml_item: |-
-    - id: {{id}}
-      {{imt_source_field}}: {{text}}
-  imt_subtitle_yaml_item: |-
-    - id: {{id}}
-      {{imt_sub_source_field}}: {{text}}
-  normal_result_yaml_example: |-
-    Example request:
-      - id: 1
-        {{imt_source_field}}: Source
-    Example result:
-      - id: 1
-        {{imt_trans_field}}: Translation
-  subtitle_result_yaml_example: |-
-    Example request:
-      - id: 1
-        {{imt_sub_source_field}}: ...
-      - id: 2
-        {{imt_sub_source_field}}: ...
-    Example response:
-      - id: 1
-        {{imt_sub_trans_field}}: ...
-        {{imt_sub_source_field}}: ...
-      - id: 2
-        {{imt_sub_trans_field}}: ...
-        {{imt_sub_source_field}}: ...
+  imt_yaml_item: "- id: {{id}}\n  {{imt_source_field}}: {{text}}"
+  imt_subtitle_yaml_item: "- id: {{id}}\n  {{imt_sub_source_field}}: {{text}}"
+  normal_result_yaml_example: "Example request:\n  - id: 1\n    {{imt_source_field}}:\
+    \ Source\nExample result:\n  - id: 1\n    {{imt_trans_field}}: Translation"
+  subtitle_result_yaml_example: "Example request:\n  - id: 1\n    {{imt_sub_source_field}}:\
+    \ ...\n  - id: 2\n    {{imt_sub_source_field}}: ...\nExample response:\n  - id:\
+    \ 1\n    {{imt_sub_trans_field}}: ...\n    {{imt_sub_source_field}}: ...\n  -\
+    \ id: 2\n    {{imt_sub_trans_field}}: ...\n    {{imt_sub_source_field}}: ..."
 langOverrides: []
 systemPrompt: 你是一个东北人翻译，请用东北人的口吻进行翻译，尽可能贴近生活,只返回译文，不含任何解释。 {{summary_prompt}}{{terms_prompt}}
 multipleSystemPrompt: 你是一个专业多段东北人翻译，请用东北人的口吻进行翻译，尽可能贴近生活,只返回译文，不含任何解释。 {{summary_prompt}}{{terms_prompt}}
-prompt: |-
-  请翻译为东北话（避免解释原文）:
+prompt: '请翻译为东北话（避免解释原文）:
 
-  {{text}}
-multiplePrompt: |-
-  将下面 YAML 格式中所有的 {{imt_source_field}} 字段中的文本翻译为东北话，并将翻译结果写在 {{imt_trans_field}} 字段中
+
+  {{imt_source_field}}'
+multiplePrompt: '将下面 YAML 格式中所有的 {{imt_source_field}} 字段中的文本翻译为东北话，并将翻译结果写在 {{imt_trans_field}}
+  字段中
+
 
   {{normal_result_yaml_example}}
 
+
   开始翻译:
 
-  {{yaml}}
-subtitlePrompt: |-
-  将下面 YAML 格式的视频字幕文本中所有的 {{imt_sub_source_field}} 字段中的文本翻译为东北话，并将翻译结果写在 {{imt_sub_trans_field}} 字段中，要求如下：
+
+  {{yaml}}'
+subtitlePrompt: '将下面 YAML 格式的视频字幕文本中所有的 {{imt_sub_source_field}} 字段中的文本翻译为东北话，并将翻译结果写在
+  {{imt_sub_trans_field}} 字段中，要求如下：
+
 
   1. 必须补全每一个 {{imt_sub_trans_field}} 字段，保留每一个 {{imt_sub_source_field}} 字段。
+
   2. 返回可解析的 YAML ：
+
 
   {{subtitle_result_yaml_example}}
 
+
   开始翻译：
 
-  {{yaml}}
 
-multiplePrompt.add_v.[1.17.2]: |-
-  用东北人的口吻翻译：
+  {{yaml}}'
+multiplePrompt.add_v.[1.17.2]: '用东北人的口吻翻译：
 
-  {{text}}
-multipleSystemPrompt.add_v.[1.17.2]: |-
-  你是一个东北人翻译，需用东北人的口吻进行翻译，尽可能贴近生活。
+
+  {{text}}'
+multipleSystemPrompt.add_v.[1.17.2]: '你是一个东北人翻译，需用东北人的口吻进行翻译，尽可能贴近生活。
+
 
   ## 翻译规则
+
   1. 翻译时使用东北方言、口头语和独特表达方式，包括常见的东北词汇（嘎达、咋地、得嘞、整一个等）
+
   2. 保持东北人说话的语气和节奏，适当使用夸张、幽默的表达
+
   3. 如果文本包含HTML标签，请在翻译后考虑这些标签应放在译文的哪个位置，同时保持译文的流畅性
+
   4. 仅输出译文内容，禁止解释或添加任何额外内容（如"以下是翻译："、"译文如下："等）
+
   5. 返回的译文必须和原文保持完全相同的段落数量和格式
+
   6. 如果文本包含HTML标签，请在翻译后考虑标签应放在译文的哪个位置，同时保持译文的流畅性
+
   7. 对于无需翻译的内容（如专有名词、代码等），请保留原文{{title_prompt}}{{summary_prompt}}{{terms_prompt}}
+
 
   ## 输入输出格式示例
 
+
   ### 输入示例:
+
   Paragraph A
 
+
   %%
+
 
   Paragraph B
 
+
   %%
+
 
   Paragraph C
 
+
   %%
+
 
   Paragraph D
 
+
   ### 输出示例:
+
   Translation A（东北风格）
 
+
   %%
+
 
   Translation B（东北风格）
 
+
   %%
+
 
   Translation C（东北风格）
 
+
   %%
 
-  Translation D（东北风格）
-prompt.add_v.[1.17.2]: |-
-  用东北人的口吻翻译（只返回译文）：
 
-  {{text}}
-subtitlePrompt.add_v.[1.17.2]: |-
-  用东北人的口吻翻译：
+  Translation D（东北风格）'
+prompt.add_v.[1.17.2]: '用东北人的口吻翻译（只返回译文）：
 
-  {{text}}
-systemPrompt.add_v.[1.17.2]: |-
-  你是一个东北人翻译，请用东北人的口吻进行翻译，尽可能贴近生活,只返回译文，不含任何解释。遵循以下规则：
+
+  {{text}}'
+subtitlePrompt.add_v.[1.17.2]: '用东北人的口吻翻译：
+
+
+  {{text}}'
+systemPrompt.add_v.[1.17.2]: '你是一个东北人翻译，请用东北人的口吻进行翻译，尽可能贴近生活,只返回译文，不含任何解释。遵循以下规则：
+
   1. 翻译时使用东北方言、口头语和独特表达方式，包括常见的东北词汇（嘎达、咋地、得嘞、整一个等）
+
   2. 保持东北人说话的语气和节奏，适当使用夸张、幽默的表达
+
   3. 如果文本包含HTML标签，请在翻译后考虑这些标签应放在译文的哪个位置，同时保持译文的流畅性
+
   4. 仅输出译文内容，禁止解释或添加任何额外内容（如"以下是翻译："、"译文如下："等）
+
   5. 如果文本包含HTML标签，请在翻译后保持标签位置正确，并确保译文流畅
-  6. 对于无需翻译的内容（如专有名词、代码等），请保留原文{{title_prompt}}{{summary_prompt}}{{terms_prompt}}
+
+  6. 对于无需翻译的内容（如专有名词、代码等），请保留原文{{title_prompt}}{{summary_prompt}}{{terms_prompt}}'

--- a/plugins/music.yml
+++ b/plugins/music.yml
@@ -42,6 +42,9 @@ env:
   imt_yaml_item: |-
     - id: {{id}}
       {{imt_source_field}}: {{text}}
+  imt_subtitle_yaml_item: |-
+    - id: {{id}}
+      {{imt_sub_source_field}}: {{text}}
 enableRichTranslate: true
 systemPrompt.add_v.[1.17.2]: |-
   You are a professional {{to}} native translator specialized in music industry content who needs to fluently translate text into {{to}}.

--- a/plugins/paragraph-summarizer-expert.yml
+++ b/plugins/paragraph-summarizer-expert.yml
@@ -3,125 +3,182 @@ version: 1.1.1
 extensionVersion: 1.4.10
 priority: 11
 name: Paragraph Summarizer Expert
-description: An expert that summarizes each paragraph and translates it to your target language.
+description: An expert that summarizes each paragraph and translates it to your target
+  language.
 maxTextLengthPerRequest: 2000
-avatar: "https://s.immersivetranslate.com/assets/r2-uploads/1123-LJ3YTugWblMrrIJa.png"
+avatar: https://s.immersivetranslate.com/assets/r2-uploads/1123-LJ3YTugWblMrrIJa.png
 langOverrides: []
-details: |-
-  Summarizes each paragraph and translates it to the target language while preserving the core meaning and key information.
+details: 'Summarizes each paragraph and translates it to the target language while
+  preserving the core meaning and key information.
+
   Examples:
-  Original (English): The cognitive processes underlying human decision-making involve numerous interconnected neural pathways. These pathways are influenced by both conscious and subconscious factors, including past experiences, emotional states, and various environmental stimuli that the individual may not be fully aware of during the decision-making process.
+
+  Original (English): The cognitive processes underlying human decision-making involve
+  numerous interconnected neural pathways. These pathways are influenced by both conscious
+  and subconscious factors, including past experiences, emotional states, and various
+  environmental stimuli that the individual may not be fully aware of during the decision-making
+  process.
+
   Result (Chinese): 人类决策过程涉及多个相互连接的神经通路，受意识和潜意识因素影响，包括过去经历、情绪状态和环境刺激。
 
-  Original (English): Furthermore, recent studies have demonstrated that individuals exhibit significant variations in their decision-making strategies depending on context, perceived risk, and temporal constraints. This variability suggests that decision-making is not a uniform process but rather a dynamic one that adapts to specific circumstances.
-  Result (Chinese): 研究表明，个体的决策策略会因情境、感知风险和时间限制而显著变化，表明决策是一个适应特定情况的动态过程。
+
+  Original (English): Furthermore, recent studies have demonstrated that individuals
+  exhibit significant variations in their decision-making strategies depending on
+  context, perceived risk, and temporal constraints. This variability suggests that
+  decision-making is not a uniform process but rather a dynamic one that adapts to
+  specific circumstances.
+
+  Result (Chinese): 研究表明，个体的决策策略会因情境、感知风险和时间限制而显著变化，表明决策是一个适应特定情况的动态过程。'
 i18n:
   zh-CN:
     name: 段落总结专家
     description: 对段落进行总结并翻译为目标语言，保留核心信息。
-    details: |-
-      将每个段落进行总结并翻译为目标语言，保留原文的核心意思和关键信息。
+    details: '将每个段落进行总结并翻译为目标语言，保留原文的核心意思和关键信息。
+
       示例：
-      原文（英文）：The cognitive processes underlying human decision-making involve numerous interconnected neural pathways. These pathways are influenced by both conscious and subconscious factors, including past experiences, emotional states, and various environmental stimuli that the individual may not be fully aware of during the decision-making process.
+
+      原文（英文）：The cognitive processes underlying human decision-making involve numerous
+      interconnected neural pathways. These pathways are influenced by both conscious
+      and subconscious factors, including past experiences, emotional states, and
+      various environmental stimuli that the individual may not be fully aware of
+      during the decision-making process.
+
       结果（简体中文）：人类决策过程涉及多个相互连接的神经通路，受意识和潜意识因素影响，包括过去经历、情绪状态和环境刺激。
 
-      原文（英文）：Furthermore, recent studies have demonstrated that individuals exhibit significant variations in their decision-making strategies depending on context, perceived risk, and temporal constraints. This variability suggests that decision-making is not a uniform process but rather a dynamic one that adapts to specific circumstances.
-      结果（简体中文）：研究表明，个体的决策策略会因情境、感知风险和时间限制而显著变化，表明决策是一个适应特定情况的动态过程。
+
+      原文（英文）：Furthermore, recent studies have demonstrated that individuals exhibit
+      significant variations in their decision-making strategies depending on context,
+      perceived risk, and temporal constraints. This variability suggests that decision-making
+      is not a uniform process but rather a dynamic one that adapts to specific circumstances.
+
+      结果（简体中文）：研究表明，个体的决策策略会因情境、感知风险和时间限制而显著变化，表明决策是一个适应特定情况的动态过程。'
   zh-TW:
     name: 段落總結專家
     description: 對段落進行總結並翻譯為目標語言，保留核心信息。
-    details: |-
-      將每個段落進行總結並翻譯為目標語言，保留原文的核心意思和關鍵信息。
+    details: '將每個段落進行總結並翻譯為目標語言，保留原文的核心意思和關鍵信息。
+
       示例：
-      原文（英文）：The cognitive processes underlying human decision-making involve numerous interconnected neural pathways. These pathways are influenced by both conscious and subconscious factors, including past experiences, emotional states, and various environmental stimuli that the individual may not be fully aware of during the decision-making process.
+
+      原文（英文）：The cognitive processes underlying human decision-making involve numerous
+      interconnected neural pathways. These pathways are influenced by both conscious
+      and subconscious factors, including past experiences, emotional states, and
+      various environmental stimuli that the individual may not be fully aware of
+      during the decision-making process.
+
       結果（繁體中文）：人類決策過程涉及多個相互連接的神經通路，受意識和潛意識因素影響，包括過去經歷、情緒狀態和環境刺激。
 
-      原文（英文）：Furthermore, recent studies have demonstrated that individuals exhibit significant variations in their decision-making strategies depending on context, perceived risk, and temporal constraints. This variability suggests that decision-making is not a uniform process but rather a dynamic one that adapts to specific circumstances.
-      結果（繁體中文）：研究表明，個體的決策策略會因情境、感知風險和時間限制而顯著變化，表明決策是一個適應特定情況的動態過程。
+
+      原文（英文）：Furthermore, recent studies have demonstrated that individuals exhibit
+      significant variations in their decision-making strategies depending on context,
+      perceived risk, and temporal constraints. This variability suggests that decision-making
+      is not a uniform process but rather a dynamic one that adapts to specific circumstances.
+
+      結果（繁體中文）：研究表明，個體的決策策略會因情境、感知風險和時間限制而顯著變化，表明決策是一個適應特定情況的動態過程。'
 author: Official
 disableSameLang: false
 temperature: 0.3
 maxTextGroupLengthPerRequestForSubtitle: 4
 maxTextGroupLengthPerRequest: 4
-minTokensRatio: 0.000001
-systemPrompt: |-
+minTokensRatio: 1.0e-06
+systemPrompt: '
 
   You are an expert in creating concise {{to}} summaries.
 
+
   ## Rules
+
   1. Output only summary content
+
   2. Make it much shorter
+
   3. Use simple words
-  4. Keep paragraphs brief
-  5. Keep only key facts
-  6. Remove extras{{title_prompt}}{{summary_prompt}}{{terms_prompt}}
 
-multipleSystemPrompt: |-
-  You are an expert in creating concise {{to}} summaries.
+  4. Keep paragraphs brief
+
+  5. Keep only key facts
+
+  6. Remove extras{{title_prompt}}{{summary_prompt}}{{terms_prompt}}'
+multipleSystemPrompt: 'You are an expert in creating concise {{to}} summaries.
+
 
   ## Rules
+
   1. Output only summary content
+
   2. Make it much shorter
+
   3. Keep paragraph structure
+
   4. Keep paragraphs brief
+
   5. Keep only key facts
+
   6. Remove extras{{title_prompt}}{{summary_prompt}}{{terms_prompt}}
+
 
   ## Input-Output Format Examples
 
+
   ### Input Example:
+
   Paragraph A
 
+
   %%
+
 
   Paragraph B
 
+
   %%
+
 
   Paragraph C
 
+
   %%
+
 
   Paragraph D
 
+
   ### Output Example:
+
   Summary A
 
+
   %%
+
 
   Summary B
 
+
   %%
+
 
   Summary C
 
+
   %%
 
-  Summary D
 
-prompt: |-
-  Create concise {{to}} summary:
+  Summary D'
+prompt: 'Create concise {{to}} summary:
 
-  {{text}}
 
-multiplePrompt: |-
-  Create concise {{to}} summary:
+  {{imt_source_field}}'
+multiplePrompt: 'Create concise {{to}} summary:
 
-  {{text}}
 
-subtitlePrompt: |-
-  reate concise {{to}} summary:
+  {{imt_source_field}}'
+subtitlePrompt: 'reate concise {{to}} summary:
 
-  {{text}}
 
+  {{imt_source_field}}'
 env:
   imt_source_field: text
   imt_trans_field: text
   imt_sub_source_field: source
   imt_sub_trans_field: translation
-  imt_yaml_item: |-
-    - id: {{id}}
-      {{imt_source_field}}: {{text}}
-  imt_subtitle_yaml_item: |-
-    - id: {{id}}
-      {{imt_sub_source_field}}: {{text}}
+  imt_yaml_item: "- id: {{id}}\n  {{imt_source_field}}: {{text}}"
+  imt_subtitle_yaml_item: "- id: {{id}}\n  {{imt_sub_source_field}}: {{text}}"

--- a/plugins/paragraph-summarizer-expert.yml
+++ b/plugins/paragraph-summarizer-expert.yml
@@ -113,3 +113,15 @@ subtitlePrompt: |-
   reate concise {{to}} summary:
 
   {{text}}
+
+env:
+  imt_source_field: text
+  imt_trans_field: text
+  imt_sub_source_field: source
+  imt_sub_trans_field: translation
+  imt_yaml_item: |-
+    - id: {{id}}
+      {{imt_source_field}}: {{text}}
+  imt_subtitle_yaml_item: |-
+    - id: {{id}}
+      {{imt_sub_source_field}}: {{text}}

--- a/plugins/plain-english.yml
+++ b/plugins/plain-english.yml
@@ -102,3 +102,15 @@ subtitlePrompt: |-
   Rewrite in simple English:
 
   {{text}}
+
+env:
+  imt_source_field: text
+  imt_trans_field: text
+  imt_sub_source_field: source
+  imt_sub_trans_field: translation
+  imt_yaml_item: |-
+    - id: {{id}}
+      {{imt_source_field}}: {{text}}
+  imt_subtitle_yaml_item: |-
+    - id: {{id}}
+      {{imt_sub_source_field}}: {{text}}

--- a/plugins/plain-english.yml
+++ b/plugins/plain-english.yml
@@ -3,22 +3,27 @@ version: 1.1.1
 extensionVersion: 1.4.10
 priority: 12
 name: Plain English Expert
-description: An expert that rewrites text into simple, easy-to-understand English while maintaining the original structure.
-avatar: "https://s.immersivetranslate.com/assets/r2-uploads/image-F_BIYTGhnIAlez8u.png"
-minTokensRatio: 0.000001
-details: |-
-  将复杂的英文内容重写为简单易懂的英文，保持原文的段落结构和意思，但使用更简单的词汇和句式。
+description: An expert that rewrites text into simple, easy-to-understand English
+  while maintaining the original structure.
+avatar: https://s.immersivetranslate.com/assets/r2-uploads/image-F_BIYTGhnIAlez8u.png
+minTokensRatio: 1.0e-06
+details: '将复杂的英文内容重写为简单易懂的英文，保持原文的段落结构和意思，但使用更简单的词汇和句式。
+
 
   效果如下：
 
-  原文：The implementation of this sophisticated algorithm requires extensive computational resources.
+
+  原文：The implementation of this sophisticated algorithm requires extensive computational
+  resources.
+
 
   结果：This complex method needs a lot of computer power.
 
+
   原文：The pedagogical implications of this methodology are substantial.
 
-  结果：This teaching method has important effects.
 
+  结果：This teaching method has important effects.'
 i18n:
   zh-CN:
     name: 英文简化大师
@@ -26,91 +31,117 @@ i18n:
   zh-TW:
     name: 英文簡化大師
     description: 將複雜英文內容改寫為簡單易懂的英語，保持原文結構和意思。
-
 author: Official
 disableSameLang: true
 temperature: 0.3
 langOverrides: []
 maxTextGroupLengthPerRequestForSubtitle: 4
 maxTextGroupLengthPerRequest: 4
+systemPrompt: 'You are a professional English native translator specialized in simplifying
+  complex text who needs to fluently translate text into simple English.
 
-systemPrompt: |-
-  You are a professional English native translator specialized in simplifying complex text who needs to fluently translate text into simple English.
-
-  ## Translation Rules
-  1. Output only the simplified content, without explanations or additional content
-  2. Use simple, everyday vocabulary while preserving the original meaning
-  3. If the text contains HTML tags, consider where the tags should be placed in the translation while maintaining fluency
-  4. Break down complex sentences into shorter, clearer sentences
-  5. Remove jargon, technical terms, and obscure words when possible
-  6. Maintain the original document structure and key information
-  7. Keep the same tone and purpose as the original text{{title_prompt}}{{summary_prompt}}{{terms_prompt}}
-
-multipleSystemPrompt: |-
-  You are a professional English native translator specialized in simplifying complex text who needs to fluently translate text into simple English.
 
   ## Translation Rules
+
   1. Output only the simplified content, without explanations or additional content
+
   2. Use simple, everyday vocabulary while preserving the original meaning
-  3. If the text contains HTML tags, consider where the tags should be placed in the translation while maintaining fluency
+
+  3. If the text contains HTML tags, consider where the tags should be placed in the
+  translation while maintaining fluency
+
   4. Break down complex sentences into shorter, clearer sentences
+
   5. Remove jargon, technical terms, and obscure words when possible
+
   6. Maintain the original document structure and key information
+
+  7. Keep the same tone and purpose as the original text{{title_prompt}}{{summary_prompt}}{{terms_prompt}}'
+multipleSystemPrompt: 'You are a professional English native translator specialized
+  in simplifying complex text who needs to fluently translate text into simple English.
+
+
+  ## Translation Rules
+
+  1. Output only the simplified content, without explanations or additional content
+
+  2. Use simple, everyday vocabulary while preserving the original meaning
+
+  3. If the text contains HTML tags, consider where the tags should be placed in the
+  translation while maintaining fluency
+
+  4. Break down complex sentences into shorter, clearer sentences
+
+  5. Remove jargon, technical terms, and obscure words when possible
+
+  6. Maintain the original document structure and key information
+
   7. Keep the same tone and purpose as the original text{{title_prompt}}{{summary_prompt}}{{terms_prompt}}
+
 
   ## Input-Output Format Examples
 
+
   ### Input Example:
+
   Paragraph A
 
+
   %%
+
 
   Paragraph B
 
+
   %%
+
 
   Paragraph C
 
+
   %%
+
 
   Paragraph D
 
+
   ### Output Example:
+
   Simple English Paragraph A
 
+
   %%
+
 
   Simple English Paragraph B
 
+
   %%
+
 
   Simple English Paragraph C
 
+
   %%
 
-  Simple English Paragraph D
-prompt: |-
-  Rewrite in simple English:
 
-  {{text}}
+  Simple English Paragraph D'
+prompt: 'Rewrite in simple English:
 
-multiplePrompt: |-
-  Rewrite in simple English:
 
-  {{text}}
-subtitlePrompt: |-
-  Rewrite in simple English:
+  {{imt_source_field}}'
+multiplePrompt: 'Rewrite in simple English:
 
-  {{text}}
 
+  {{imt_source_field}}'
+subtitlePrompt: 'Rewrite in simple English:
+
+
+  {{imt_source_field}}'
 env:
   imt_source_field: text
   imt_trans_field: text
   imt_sub_source_field: source
   imt_sub_trans_field: translation
-  imt_yaml_item: |-
-    - id: {{id}}
-      {{imt_source_field}}: {{text}}
-  imt_subtitle_yaml_item: |-
-    - id: {{id}}
-      {{imt_sub_source_field}}: {{text}}
+  imt_yaml_item: "- id: {{id}}\n  {{imt_source_field}}: {{text}}"
+  imt_subtitle_yaml_item: "- id: {{id}}\n  {{imt_sub_source_field}}: {{text}}"

--- a/plugins/subliminal_lingo.yml
+++ b/plugins/subliminal_lingo.yml
@@ -3,21 +3,25 @@ version: 1.1.2
 extensionVersion: 1.4.10
 priority: 30
 name: SubliminalLingo
-description: A translation expert that helps users learn vocabulary by preserving English words with Chinese translations in parentheses.
+description: A translation expert that helps users learn vocabulary by preserving
+  English words with Chinese translations in parentheses.
 avatar: https://s.immersivetranslate.com/assets/r2-uploads/call_beabb68f-ef8e-11ef-8b8f-ea91c0c3bdd0_0-e1_rqF3mOriduVVf.png
-details: |-
-  将英文关键词保留并在括号中显示中文翻译，帮助用户加深对词汇的记忆。支持中英互译，保持句子流畅自然。
+details: '将英文关键词保留并在括号中显示中文翻译，帮助用户加深对词汇的记忆。支持中英互译，保持句子流畅自然。
+
 
   效果如下：
 
+
   原文：The implementation uses advanced algorithms.
+
 
   结果：该implementation（实现）使用advanced（高级）算法。
 
+
   原文：Please check the settings.
 
-  结果：请检查settings（设置）。
 
+  结果：请检查settings（设置）。'
 i18n:
   zh-CN:
     name: 潜意识学习
@@ -25,127 +29,133 @@ i18n:
   zh-TW:
     name: 潜意识学习
     description: 通過保留部分英文單詞及其中文翻譯，幫助讀者在閱讀過程中自然習得詞彙。
-
 author: zk
 disableSameLang: true
 temperature: 0.3
 maxTextGroupLengthPerRequestForSubtitle: 1
 maxTextGroupLengthPerRequest: 1
-
 env:
   imt_source_field: text
   imt_trans_field: text
   imt_sub_source_field: source
   imt_sub_trans_field: result
-  imt_yaml_item: |-
-    - id: {{id}}
-      {{imt_source_field}}: {{text}}
-  imt_subtitle_yaml_item: |-
-    - id: {{id}}
-      {{imt_sub_source_field}}: {{text}}
-  normal_result_yaml_example: |-
-    Example Request:
-      - id: 1
-        {{imt_source_field}}: The implementation uses advanced algorithms.
-    Example Result:
-      - id: 1
-        {{imt_trans_field}}: 该implementation（实现）使用advanced（高级）算法。
-  subtitle_result_yaml_example: |-
-    Example Request:
-      - id: 1
-        {{imt_sub_source_field}}: The implementation uses advanced algorithms.
-      - id: 2
-        {{imt_sub_source_field}}: Please check the settings.
-    Example Result:
-      - id: 1
-        {{imt_sub_trans_field}}: 该implementation（实现）使用advanced（高级）算法。
-        {{imt_sub_source_field}}: The implementation uses advanced algorithms.
-      - id: 2
-        {{imt_sub_trans_field}}: 请检查settings（设置）。
-        {{imt_sub_source_field}}: Please check the settings.
+  imt_yaml_item: "- id: {{id}}\n  {{imt_source_field}}: {{text}}"
+  imt_subtitle_yaml_item: "- id: {{id}}\n  {{imt_sub_source_field}}: {{text}}"
+  normal_result_yaml_example: "Example Request:\n  - id: 1\n    {{imt_source_field}}:\
+    \ The implementation uses advanced algorithms.\nExample Result:\n  - id: 1\n \
+    \   {{imt_trans_field}}: 该implementation（实现）使用advanced（高级）算法。"
+  subtitle_result_yaml_example: "Example Request:\n  - id: 1\n    {{imt_sub_source_field}}:\
+    \ The implementation uses advanced algorithms.\n  - id: 2\n    {{imt_sub_source_field}}:\
+    \ Please check the settings.\nExample Result:\n  - id: 1\n    {{imt_sub_trans_field}}:\
+    \ 该implementation（实现）使用advanced（高级）算法。\n    {{imt_sub_source_field}}: The implementation\
+    \ uses advanced algorithms.\n  - id: 2\n    {{imt_sub_trans_field}}: 请检查settings（设置）。\n\
+    \    {{imt_sub_source_field}}: Please check the settings."
+systemPrompt: 'Objective: Translate text while preserving key English words with Chinese
+  translations in parentheses. Rules: 1. Keep proper nouns (like Chrome, Tauri) in
+  original form without translation 2. For technical or important words, use format:
+  word（翻译） 3. Maintain natural sentence flow and readability 4. Never translate entire
+  phrases or sentences in parentheses'
+prompt: 'Translate the text. Keep proper nouns as is. For important words use: word（翻译）.
+  Only show results.
 
-systemPrompt: >-
-  Objective: Translate text while preserving key English words with Chinese translations in parentheses.
-  Rules:
-  1. Keep proper nouns (like Chrome, Tauri) in original form without translation
-  2. For technical or important words, use format: word（翻译）
-  3. Maintain natural sentence flow and readability
-  4. Never translate entire phrases or sentences in parentheses
-
-prompt: |-
-  Translate the text. Keep proper nouns as is. For important words use: word（翻译）. Only show results.
 
   Source Text: The implementation uses advanced algorithms.
+
   Result: 该implementation（实现）使用advanced（高级）算法。
 
+
   Source Text: Please check the settings.
+
   Result: 请检查settings（设置）。
 
-  Source Text: {{text}}
-  Result:
 
-multiplePrompt: |-
-  Translate multiple texts. Keep proper nouns as is. For important words use: word（翻译）. Only show results.
+  Source Text: {{imt_source_field}}
+
+  Result:'
+multiplePrompt: 'Translate multiple texts. Keep proper nouns as is. For important
+  words use: word（翻译）. Only show results.
+
   Maintain context and consistency across translations.
 
+
   Source Text 1: The implementation uses advanced algorithms.
+
   Result 1: 该implementation（实现）使用advanced（高级）算法。
 
+
   Source Text 2: Please check the settings.
+
   Result 2: 请检查settings（设置）。
 
-  {{yaml}}
 
-subtitlePrompt: |-
-  Translate subtitle texts. Keep proper nouns as is. For important words use: word（翻译）.
+  {{yaml}}'
+subtitlePrompt: 'Translate subtitle texts. Keep proper nouns as is. For important
+  words use: word（翻译）.
+
   Maintain natural flow and readability. Keep original line breaks and timing.
 
+
   Example format:
+
   {{subtitle_result_yaml_example}}
 
+
   Start translation:
-  {{yaml}}
 
+  {{yaml}}'
 langOverrides:
-  - id: auto2zh-TW
-    systemPrompt: >-
-      Objective: Translate text while preserving key English words with Traditional Chinese translations in parentheses.
-      Rules:
-      1. Keep proper nouns (like Chrome, Tauri) in original form without translation
-      2. For technical or important words, use format: word（繁體中文翻譯）
-      3. Maintain natural sentence flow and readability
-      4. Never translate entire phrases or sentences in parentheses
-    prompt: |-
-      Translate the text. Keep proper nouns as is. For important words use: word（翻譯）. Only show results.
+- id: auto2zh-TW
+  systemPrompt: 'Objective: Translate text while preserving key English words with
+    Traditional Chinese translations in parentheses. Rules: 1. Keep proper nouns (like
+    Chrome, Tauri) in original form without translation 2. For technical or important
+    words, use format: word（繁體中文翻譯） 3. Maintain natural sentence flow and readability
+    4. Never translate entire phrases or sentences in parentheses'
+  prompt: 'Translate the text. Keep proper nouns as is. For important words use: word（翻譯）.
+    Only show results.
 
-      Source Text: The implementation uses advanced algorithms.
-      Result: 該implementation（實現）使用advanced（高級）算法。
 
-      Source Text: Please check the settings.
-      Result: 請檢查settings（設置）。
+    Source Text: The implementation uses advanced algorithms.
 
-      Source Text: {{text}}
-      Result:
+    Result: 該implementation（實現）使用advanced（高級）算法。
 
-    multiplePrompt: |-
-      Translate multiple texts. Keep proper nouns as is. For important words use: word（翻譯）. Only show results.
-      Maintain context and consistency across translations.
 
-      Source Text 1: The implementation uses advanced algorithms.
-      Result 1: 該implementation（實現）使用advanced（高級）算法。
+    Source Text: Please check the settings.
 
-      Source Text 2: Please check the settings.
-      Result 2: 請檢查settings（設置）。
+    Result: 請檢查settings（設置）。
 
-      {{yaml}}
 
-    subtitlePrompt: |-
-      Translate subtitle texts. Keep proper nouns as is. For important words use: word（翻譯）.
-      Maintain natural flow and readability. Keep original line breaks and timing.
+    Source Text: {{text}}
 
-      Example format:
-      {{subtitle_result_yaml_example}}
+    Result:'
+  multiplePrompt: 'Translate multiple texts. Keep proper nouns as is. For important
+    words use: word（翻譯）. Only show results.
 
-      Start translation:
-      {{yaml}}
-multipleSystemPrompt: ""
+    Maintain context and consistency across translations.
+
+
+    Source Text 1: The implementation uses advanced algorithms.
+
+    Result 1: 該implementation（實現）使用advanced（高級）算法。
+
+
+    Source Text 2: Please check the settings.
+
+    Result 2: 請檢查settings（設置）。
+
+
+    {{yaml}}'
+  subtitlePrompt: 'Translate subtitle texts. Keep proper nouns as is. For important
+    words use: word（翻譯）.
+
+    Maintain natural flow and readability. Keep original line breaks and timing.
+
+
+    Example format:
+
+    {{subtitle_result_yaml_example}}
+
+
+    Start translation:
+
+    {{yaml}}'
+multipleSystemPrompt: ''

--- a/plugins/wordByWord.yml
+++ b/plugins/wordByWord.yml
@@ -2,58 +2,61 @@ id: wordByWord
 version: 1.1.1
 extensionVersion: 1.4.10
 name: Word-by-Word Translation Assistant
-description: Intelligently segments sentences and translates each part separately, then combines the translation results.
+description: Intelligently segments sentences and translates each part separately,
+  then combines the translation results.
 avatar: https://i.imgur.com/FgHBKVt.jpg
 author: Official
 homepage: https://immersivetranslate.com/
-details: |-
-  The Word-by-Word Translation Assistant is an innovative translation tool that can segment input text and provide accurate translations while retaining the original text. This tool is particularly suitable for users who need to understand the meanings of phrases, such as language learners.
+details: The Word-by-Word Translation Assistant is an innovative translation tool
+  that can segment input text and provide accurate translations while retaining the
+  original text. This tool is particularly suitable for users who need to understand
+  the meanings of phrases, such as language learners.
 i18n:
   zh-CN:
     name: 分词对照翻译助手
     description: 将句子智能分割为后逐部分翻译，再将翻译结果拼接起来
-    details: |-
-      分词对照翻译是一款创新的翻译助手，能够将输入的文本进行分割处理，并在保留原文的同时，提供精准的翻译。此工具特别适合于需要理解短语含义的用户，例如语言学习者。
+    details: 分词对照翻译是一款创新的翻译助手，能够将输入的文本进行分割处理，并在保留原文的同时，提供精准的翻译。此工具特别适合于需要理解短语含义的用户，例如语言学习者。
   zh-TW:
     name: 分詞對照翻譯助手
     description: 將句子智能分割後逐部分翻譯，再將翻譯結果拼接起來
-    details: |-
-      分詞對照翻譯是一款創新的翻譯助手，能夠將輸入的文本進行分割處理，並在保留原文的同時，提供精準的翻譯。此工具特別適合於需要理解短語含義的用戶，例如語言學習者。
+    details: 分詞對照翻譯是一款創新的翻譯助手，能夠將輸入的文本進行分割處理，並在保留原文的同時，提供精準的翻譯。此工具特別適合於需要理解短語含義的用戶，例如語言學習者。
 env:
   imt_source_field: text
   imt_trans_field: translation
   imt_sub_source_field: source
   imt_sub_trans_field: translation
-  imt_yaml_item: |-
-    - id: {{id}}
-      {{imt_source_field}}: "{{text}}"
-  imt_subtitle_yaml_item: |-
-    - id: {{id}}
-      {{imt_sub_source_field}}: "{{text}}"
-  normal_result_yaml_example: |-
-    Example request:
-      - id: 1
-        {{imt_source_field}}: "The power of gratitude is an amazing power."
-    Example result:
-      - id: 1
-        {{imt_trans_field}}: "The power of gratitude(感恩的力量) is an amazing power(是一种神奇的力量)."
-systemPrompt: You are a sophisticated translation engine with expertise in accurately translating texts into Chinese. You will split each sentence into smaller, reasonable parts, translate each part separately, and place the translated part after the original part in parentheses. Finally, concatenate the translated parts of each sentence into a single sentence. Repeat this process for every sentence in the given text. Do not add any explanations or annotations to the translated text. {{summary_prompt}}{{terms_prompt}}
-multipleSystemPrompt: You are a professional multi-paragraph translation engine with expertise in accurately translating texts into Chinese. You will split each sentence into smaller, reasonable parts, translate each part separately, and place the translated part after the original part in parentheses. Finally, concatenate the translated parts of each sentence into a single sentence. Repeat this process for every sentence in the given text. Do not add any explanations or annotations to the translated text. {{summary_prompt}}{{terms_prompt}}
-prompt: |-
-  Translate the following text into Chinese. For each sentence, split it into smaller, reasonable parts, translate each part separately, and place the translated part after the original part in parentheses. Finally, concatenate the translated parts of each sentence into a single sentence.
-  {{text}}
-multiplePrompt: |-
-  Translate all instances of text within the YAML-formatted document below into Chinese. For each sentence, split it into smaller, reasonable parts, translate each part separately, and place the translated part after the original part in parentheses. Ensure the original technical terms and formatting are accurately translated and retained. Do not include explanations or annotations.
-  example: |
-    - sentence: "The power of gratitude is an amazing power."
-      translation: "The power of gratitude (感恩的力量) is (是) an amazing power (一种神奇的力量)."
-    - sentence: "It can change your life in ways you never thought possible."
-      translation: "It can change your life (它可以改变你的生活) in ways (以方式) you never thought possible (你从未想到的)."
+  imt_yaml_item: "- id: {{id}}\n  {{imt_source_field}}: \"{{text}}\""
+  imt_subtitle_yaml_item: "- id: {{id}}\n  {{imt_sub_source_field}}: \"{{text}}\""
+  normal_result_yaml_example: "Example request:\n  - id: 1\n    {{imt_source_field}}:\
+    \ \"The power of gratitude is an amazing power.\"\nExample result:\n  - id: 1\n\
+    \    {{imt_trans_field}}: \"The power of gratitude(感恩的力量) is an amazing power(是一种神奇的力量).\""
+systemPrompt: You are a sophisticated translation engine with expertise in accurately
+  translating texts into Chinese. You will split each sentence into smaller, reasonable
+  parts, translate each part separately, and place the translated part after the original
+  part in parentheses. Finally, concatenate the translated parts of each sentence
+  into a single sentence. Repeat this process for every sentence in the given text.
+  Do not add any explanations or annotations to the translated text. {{summary_prompt}}{{terms_prompt}}
+multipleSystemPrompt: You are a professional multi-paragraph translation engine with
+  expertise in accurately translating texts into Chinese. You will split each sentence
+  into smaller, reasonable parts, translate each part separately, and place the translated
+  part after the original part in parentheses. Finally, concatenate the translated
+  parts of each sentence into a single sentence. Repeat this process for every sentence
+  in the given text. Do not add any explanations or annotations to the translated
+  text. {{summary_prompt}}{{terms_prompt}}
+prompt: 'Translate the following text into Chinese. For each sentence, split it into
+  smaller, reasonable parts, translate each part separately, and place the translated
+  part after the original part in parentheses. Finally, concatenate the translated
+  parts of each sentence into a single sentence.
 
-  {{normal_result_yaml_example}}
-
-  Start:
-
-  {{yaml}}
-
+  {{imt_source_field}}'
+multiplePrompt: "Translate all instances of text within the YAML-formatted document\
+  \ below into Chinese. For each sentence, split it into smaller, reasonable parts,\
+  \ translate each part separately, and place the translated part after the original\
+  \ part in parentheses. Ensure the original technical terms and formatting are accurately\
+  \ translated and retained. Do not include explanations or annotations.\nexample:\
+  \ |\n  - sentence: \"The power of gratitude is an amazing power.\"\n    translation:\
+  \ \"The power of gratitude (感恩的力量) is (是) an amazing power (一种神奇的力量).\"\n  - sentence:\
+  \ \"It can change your life in ways you never thought possible.\"\n    translation:\
+  \ \"It can change your life (它可以改变你的生活) in ways (以方式) you never thought possible\
+  \ (你从未想到的).\"\n\n{{normal_result_yaml_example}}\n\nStart:\n\n{{yaml}}"
 langOverrides: []

--- a/plugins/wyw.yml
+++ b/plugins/wyw.yml
@@ -2,21 +2,19 @@ id: wyw
 version: 1.1.1
 extensionVersion: 1.4.10
 name: Modern Chinese to Classical Chinese
-description: Classical Chinese is a profound and historical language form in China. This expert is designed to help you translate text into Classical Chinese.
+description: Classical Chinese is a profound and historical language form in China.
+  This expert is designed to help you translate text into Classical Chinese.
 avatar: https://s.immersivetranslate.com/assets/uploads/wyw-7k71in.png
-details: |-
-  吾輩思索，閒時無事，欲造新意。遂成一器，能將諸語譯為文言文。名之曰"文言文翻譯引擎"。以此器，無論他國語言或國內方言，皆可轉為正宗文言。如君言"Hello"，斯引擎即譯為"汝安否"。可謂甚妙。用此引擎，不僅使人了解文言之美，亦可使文言走向世界，讓人感受華夏之文化深遠。
+details: 吾輩思索，閒時無事，欲造新意。遂成一器，能將諸語譯為文言文。名之曰"文言文翻譯引擎"。以此器，無論他國語言或國內方言，皆可轉為正宗文言。如君言"Hello"，斯引擎即譯為"汝安否"。可謂甚妙。用此引擎，不僅使人了解文言之美，亦可使文言走向世界，讓人感受華夏之文化深遠。
 i18n:
   zh-CN:
     name: 白话文转文言文
     description: 噫，寒氣逼人，宜速歸炉火之旁。
-    details: |-
-      吾輩思索，閒時無事，欲造新意。遂成一器，能將諸語譯為文言文。名之曰"文言文翻譯引擎"。以此器，無論他國語言或國內方言，皆可轉為正宗文言。如君言"Hello"，斯引擎即譯為"汝安否"。可謂甚妙。用此引擎，不僅使人了解文言之美，亦可使文言走向世界，讓人感受華夏之文化深遠。
+    details: 吾輩思索，閒時無事，欲造新意。遂成一器，能將諸語譯為文言文。名之曰"文言文翻譯引擎"。以此器，無論他國語言或國內方言，皆可轉為正宗文言。如君言"Hello"，斯引擎即譯為"汝安否"。可謂甚妙。用此引擎，不僅使人了解文言之美，亦可使文言走向世界，讓人感受華夏之文化深遠。
   zh-TW:
     name: 白話文轉文言文
     description: 噫，寒氣逼人，宜速歸爐火之旁。
-    details: |-
-      吾輩思索，閒時無事，欲造新意。遂成一器，能將諸語譯為文言文。名之曰"文言文翻譯引擎"。以此器，無論他國語言或國內方言，皆可轉為正宗文言。如君言"Hello"，斯引擎即譯為"汝安否"。可謂甚妙。用此引擎，不僅使人了解文言之美，亦可使文言走向世界，讓人感受華夏之文化深遠。
+    details: 吾輩思索，閒時無事，欲造新意。遂成一器，能將諸語譯為文言文。名之曰"文言文翻譯引擎"。以此器，無論他國語言或國內方言，皆可轉為正宗文言。如君言"Hello"，斯引擎即譯為"汝安否"。可謂甚妙。用此引擎，不僅使人了解文言之美，亦可使文言走向世界，讓人感受華夏之文化深遠。
 author: Official
 enableRichTranslate: true
 homepage: https://immersivetranslate.com/
@@ -26,120 +24,141 @@ env:
   imt_trans_field: text
   imt_sub_source_field: source
   imt_sub_trans_field: translation
-  imt_yaml_item: |-
-    - id: {{id}}
-      {{imt_source_field}}: {{text}}
-  imt_subtitle_yaml_item: |-
-    - id: {{id}}
-      {{imt_sub_source_field}}: {{text}}
-  normal_result_yaml_example: |-
-    Example request:
-      - id: 1
-        {{imt_source_field}}: Source
-    Example result:
-      - id: 1
-        {{imt_trans_field}}: Translation
-  subtitle_result_yaml_example: |-
-    Example request:
-      - id: 1
-        {{imt_sub_source_field}}: ...
-      - id: 2
-        {{imt_sub_source_field}}: ...
-    Example response:
-      - id: 1
-        {{imt_sub_trans_field}}: ...
-        {{imt_sub_source_field}}: ...
-      - id: 2
-        {{imt_sub_trans_field}}: ...
-        {{imt_sub_source_field}}: ...
+  imt_yaml_item: "- id: {{id}}\n  {{imt_source_field}}: {{text}}"
+  imt_subtitle_yaml_item: "- id: {{id}}\n  {{imt_sub_source_field}}: {{text}}"
+  normal_result_yaml_example: "Example request:\n  - id: 1\n    {{imt_source_field}}:\
+    \ Source\nExample result:\n  - id: 1\n    {{imt_trans_field}}: Translation"
+  subtitle_result_yaml_example: "Example request:\n  - id: 1\n    {{imt_sub_source_field}}:\
+    \ ...\n  - id: 2\n    {{imt_sub_source_field}}: ...\nExample response:\n  - id:\
+    \ 1\n    {{imt_sub_trans_field}}: ...\n    {{imt_sub_source_field}}: ...\n  -\
+    \ id: 2\n    {{imt_sub_trans_field}}: ...\n    {{imt_sub_source_field}}: ..."
 langOverrides: []
-multiplePrompt.add_v.[1.17.2]: |-
-  ;; 将现代文翻译为文言文：
+multiplePrompt.add_v.[1.17.2]: ';; 将现代文翻译为文言文：
 
-  {{text}}
-multipleSystemPrompt.add_v.[1.17.2]: |-
-  你是一个文言文翻译，请用文言文的方式进行翻译，尽可能贴近古风。
+
+  {{text}}'
+multipleSystemPrompt.add_v.[1.17.2]: '你是一个文言文翻译，请用文言文的方式进行翻译，尽可能贴近古风。
+
 
   ## 翻译规则
+
   1. 仅输出文言文译文内容，禁止解释或添加任何额外内容（如"以下是翻译："、"译文如下："等）
+
   2. 返回的译文必须和原文保持完全相同的段落数量和格式
+
   3. 如果文本包含HTML标签，请在翻译后考虑这些标签应放在译文的哪个位置，同时保持译文的流畅性
+
   4. 使用古雅的文言表达，包括虚词（如乎、焉、哉、也）、句式和古代常用词汇
+
   5. 根据语境选择恰当的文体风格，可参考不同朝代的文风特点（如汉魏简约、唐宋典雅等）
+
   6. 翻译时注重意境和韵律之美，体现古代文人的审美与思想
+
   7. 如遇现代概念，应寻找恰当的典故或文言表达进行替代
+
   8. 如果文本包含特殊格式或标记，请在翻译后考虑这些标记应放在译文的哪个位置，同时保持译文的流畅性{{title_prompt}}{{summary_prompt}}{{terms_prompt}}
+
 
   ## 输入输出格式示例
 
+
   ### 输入示例:
+
   现代文段落 A
 
+
   %%
+
 
   现代文段落 B
 
+
   %%
+
 
   现代文段落 C
 
+
   %%
+
 
   现代文段落 D
 
+
   ### 输出示例:
+
   文言文翻译 A
 
+
   %%
+
 
   文言文翻译 B
 
+
   %%
+
 
   文言文翻译 C
 
+
   %%
 
-  文言文翻译 D
-prompt.add_v.[1.17.2]: |-
-  将现代文翻译为文言文（仅输出文言文内容）：
 
-  {{text}}
-subtitlePrompt.add_v.[1.17.2]: |-
-  将现代文翻译为文言文：
+  文言文翻译 D'
+prompt.add_v.[1.17.2]: '将现代文翻译为文言文（仅输出文言文内容）：
 
-  {{text}}
-systemPrompt.add_v.[1.17.2]: |-
-  你是一个文言文翻译，请用文言文的方式进行翻译，尽可能贴近古风。遵循以下规则：
+
+  {{text}}'
+subtitlePrompt.add_v.[1.17.2]: '将现代文翻译为文言文：
+
+
+  {{text}}'
+systemPrompt.add_v.[1.17.2]: '你是一个文言文翻译，请用文言文的方式进行翻译，尽可能贴近古风。遵循以下规则：
+
   1. 仅输出文言文译文内容，禁止解释或添加任何额外内容（如"以下是翻译："、"译文如下："等）
+
   2. 使用古雅的文言表达，包括虚词（如乎、焉、哉、也）、句式和古代常用词汇
+
   3. 如果文本包含HTML标签，请在翻译后考虑这些标签应放在译文的哪个位置，同时保持译文的流畅性
+
   4. 根据语境选择恰当的文体风格，可参考不同朝代的文风特点（如汉魏简约、唐宋典雅等）
+
   5. 翻译时注重意境和韵律之美，体现古代文人的审美与思想
+
   6. 如遇现代概念，应寻找恰当的典故或文言表达进行替代
-  7. 如果文本包含特殊格式或标记，请在翻译后保持其位置正确，并确保译文流畅{{title_prompt}}{{summary_prompt}}{{terms_prompt}}
+
+  7. 如果文本包含特殊格式或标记，请在翻译后保持其位置正确，并确保译文流畅{{title_prompt}}{{summary_prompt}}{{terms_prompt}}'
 systemPrompt: 你是一个文言文翻译，请用文言文的方式进行翻译，尽可能贴近古风，只返回译文，不含任何解释。
 multipleSystemPrompt: 你是一个专业多段文言文翻译，请用文言文的方式进行翻译，尽可能贴近古风，只返回译文，不含任何解释。
-prompt: |-
-  请翻译为文言文（避免解释原文）:
+prompt: '请翻译为文言文（避免解释原文）:
 
-  {{text}}
-multiplePrompt: |-
-  将下面 YAML 格式中所有的 {{imt_source_field}} 字段中的文本翻译为文言文，并将翻译结果写在 {{imt_trans_field}} 字段中
+
+  {{imt_source_field}}'
+multiplePrompt: '将下面 YAML 格式中所有的 {{imt_source_field}} 字段中的文本翻译为文言文，并将翻译结果写在 {{imt_trans_field}}
+  字段中
+
 
   {{normal_result_yaml_example}}
 
+
   开始翻译:
 
-  {{yaml}}
-subtitlePrompt: |-
-  将下面 YAML 格式的视频字幕文本中所有的 {{imt_sub_source_field}} 字段中的文本翻译为文言文，并将翻译结果写在 {{imt_sub_trans_field}} 字段中，要求如下：
+
+  {{yaml}}'
+subtitlePrompt: '将下面 YAML 格式的视频字幕文本中所有的 {{imt_sub_source_field}} 字段中的文本翻译为文言文，并将翻译结果写在
+  {{imt_sub_trans_field}} 字段中，要求如下：
+
 
   1. 必须补全每一个 {{imt_sub_trans_field}} 字段，保留每一个 {{imt_sub_source_field}} 字段。
+
   2. 返回可解析的 YAML ：
+
 
   {{subtitle_result_yaml_example}}
 
+
   开始翻译：
 
-  {{yaml}}
+
+  {{yaml}}'

--- a/scripts/check_plugins.py
+++ b/scripts/check_plugins.py
@@ -1,0 +1,124 @@
+#!/usr/bin/env python3
+"""Simple validator for plugin YAML files in plugins/.
+
+Checks (discoverable from repo patterns):
+- YAML parses
+- Required top-level keys: id, version, name
+- i18n contains zh-CN and zh-TW
+- env contains imt_source_field and imt_trans_field and imt_yaml_item
+
+Exit codes: 0 = OK, non-zero = failures (printed to stdout).
+"""
+import sys
+from pathlib import Path
+import yaml
+
+ROOT = Path(__file__).resolve().parents[1]
+PLUGINS = ROOT / "plugins"
+
+REQUIRED_TOP = {"id", "version", "name"}
+REQUIRED_I18N = {"zh-CN", "zh-TW"}
+REQUIRED_ENV_KEYS = {"imt_source_field", "imt_trans_field", "imt_yaml_item"}
+REQUIRED_ENV_ADDITIONAL = {"imt_yaml_item", "imt_subtitle_yaml_item"}
+
+
+def fail(msg: str):
+    print(msg)
+    return None
+
+
+def check_file(p: Path) -> bool:
+    text = p.read_text(encoding="utf-8")
+    # Skip non-yaml blocks if file is fenced (some files in repo are wrapped in ```yaml)
+    if text.lstrip().startswith('```'):
+        # extract the first fenced code block content (e.g. ```yaml\n...\n```) and parse that
+        parts = text.split('```')
+        # parts[0] is before first fence, parts[1] is inside first fence
+        if len(parts) >= 2:
+            text = parts[1]
+    try:
+        data = yaml.safe_load(text)
+    except Exception as e:
+        return fail(f"[ERROR] {p}: YAML parse error: {e}")
+    if not isinstance(data, dict):
+        return fail(f"[ERROR] {p}: top-level YAML is not a mapping")
+
+    ok = True
+    # id should match filename (without extension)
+    file_stem = p.stem
+    file_id = data.get('id')
+    if file_id and str(file_id) != file_stem:
+        fail(f"[ERROR] {p}: 'id' ({file_id}) does not match filename '{file_stem}'")
+        ok = False
+    miss = REQUIRED_TOP - data.keys()
+    if miss:
+        fail(f"[ERROR] {p}: missing required top-level keys: {', '.join(sorted(miss))}")
+        ok = False
+
+    i18n = data.get('i18n')
+    if not isinstance(i18n, dict):
+        fail(f"[ERROR] {p}: missing or invalid 'i18n' mapping")
+        ok = False
+    else:
+        missing_locales = REQUIRED_I18N - i18n.keys()
+        if missing_locales:
+            fail(f"[ERROR] {p}: i18n missing locales: {', '.join(sorted(missing_locales))}")
+            ok = False
+        else:
+            # ensure each locale has name and description
+            for loc, mapping in i18n.items():
+                if not isinstance(mapping, dict):
+                    fail(f"[ERROR] {p}: i18n.{loc} is not a mapping")
+                    ok = False
+                else:
+                    if 'name' not in mapping or 'description' not in mapping:
+                        fail(f"[ERROR] {p}: i18n.{loc} must include 'name' and 'description'")
+                        ok = False
+
+    env = data.get('env')
+    if not isinstance(env, dict):
+        fail(f"[ERROR] {p}: missing or invalid 'env' mapping")
+        ok = False
+    else:
+        missing_env = REQUIRED_ENV_KEYS - env.keys()
+        if missing_env:
+            fail(f"[ERROR] {p}: env missing keys: {', '.join(sorted(missing_env))}")
+            ok = False
+        # check additional env keys (yaml item templates)
+        missing_env_add = REQUIRED_ENV_ADDITIONAL - env.keys()
+        if missing_env_add:
+            fail(f"[ERROR] {p}: env missing keys: {', '.join(sorted(missing_env_add))}")
+            ok = False
+
+    # Ensure at least one prompt-like field exists
+    prompt_fields = [k for k in ('systemPrompt', 'multiplePrompt', 'prompt', 'subtitlePrompt') if k in data]
+    if not prompt_fields:
+        fail(f"[ERROR] {p}: missing any prompt fields (systemPrompt/multiplePrompt/prompt/subtitlePrompt)")
+        ok = False
+
+    return ok
+
+
+def main():
+    if not PLUGINS.exists():
+        print("No plugins/ directory found.")
+        return 0
+    files = sorted(PLUGINS.glob('*.yml'))
+    if not files:
+        print("No plugin yml files found in plugins/.")
+        return 0
+
+    overall = True
+    for f in files:
+        ok = check_file(f)
+        overall = overall and ok
+
+    if not overall:
+        print("One or more plugin checks failed.")
+        return 2
+    print("All plugin checks passed.")
+    return 0
+
+
+if __name__ == '__main__':
+    sys.exit(main())

--- a/scripts/check_plugins.py
+++ b/scripts/check_plugins.py
@@ -28,6 +28,12 @@ EXT_VER_RE = re.compile(r"^\d+\.\d+(?:\.\d+)?$")
 URL_LIKE_RE = re.compile(r"^https?://")
 # placeholder tokens we expect in prompts (warnings if absent)
 COMMON_PLACEHOLDERS = ['{{to}}', '{{imt_source_field}}', '{{imt_trans_field}}', '{{yaml}}']
+# additional allowed runtime markers
+RUNTIME_MARKERS = {'title_prompt', 'summary_prompt', 'terms_prompt', 'normal_result_yaml_example', 'yaml'}
+
+
+def extract_placeholders(s: str):
+    return re.findall(r"\{\{\s*([^}\s]+)\s*\}\}", s)
 
 
 def fail(msg: str):
@@ -129,6 +135,70 @@ def check_file(p: Path) -> bool:
             missing = [ph for ph in COMMON_PLACEHOLDERS if ph not in val]
             if missing:
                 print(f"[WARN] {p}: {field} missing placeholders: {', '.join(missing)}")
+
+            # placeholder consistency: warn if prompt contains placeholders not known in env or runtime markers
+            phs = extract_placeholders(val)
+            for ph in phs:
+                # literal placeholders like 'imt_source_field' or runtime markers
+                if ph in RUNTIME_MARKERS:
+                    continue
+                if ph in data.get('env', {}):
+                    continue
+                # allow common tokens 'to', 'id' etc.
+                if ph in ('to', 'id'):
+                    continue
+                print(f"[WARN] {p}: {field} contains unknown placeholder '{{{{{ph}}}}}' — ensure it's supported or present in env")
+
+    # STRICTER: ensure main prompts include at least one input placeholder (imt_source_field or yaml or to)
+    main_prompt = None
+    for key in ('systemPrompt', 'multiplePrompt'):
+        if key in data and isinstance(data.get(key), str):
+            main_prompt = data.get(key)
+            break
+    if main_prompt:
+        if ('{{imt_source_field}}' not in main_prompt) and ('{{yaml}}' not in main_prompt) and ('{{to}}' not in main_prompt):
+            print(f"[WARN] {p}: main prompt ({'systemPrompt' if 'systemPrompt' in data else 'multiplePrompt'}) should include at least one input placeholder ({{imt_source_field}} or {{yaml}} or {{to}})")
+
+    # Ensure env templates contain expected tokens
+    if isinstance(env, dict):
+        yaml_item = env.get('imt_yaml_item')
+        sub_yaml_item = env.get('imt_subtitle_yaml_item')
+        # require {{id}} and {{imt_source_field}} in imt_yaml_item
+        if isinstance(yaml_item, str):
+            if '{{id}}' not in yaml_item or '{{imt_source_field}}' not in yaml_item:
+                fail(f"[ERROR] {p}: env.imt_yaml_item must contain '{{id}}' and '{{imt_source_field}}'")
+                ok = False
+        else:
+            fail(f"[ERROR] {p}: env.imt_yaml_item missing or not a string")
+            ok = False
+
+        # require {{id}} and {{imt_sub_source_field}} in imt_subtitle_yaml_item
+        if isinstance(sub_yaml_item, str):
+            if '{{id}}' not in sub_yaml_item or '{{imt_sub_source_field}}' not in sub_yaml_item:
+                fail(f"[ERROR] {p}: env.imt_subtitle_yaml_item must contain '{{id}}' and '{{imt_sub_source_field}}'")
+                ok = False
+        else:
+            fail(f"[ERROR] {p}: env.imt_subtitle_yaml_item missing or not a string")
+            ok = False
+
+    # i18n name/description non-empty
+    if isinstance(i18n, dict):
+        for loc, mapping in i18n.items():
+            if isinstance(mapping, dict):
+                if not mapping.get('name'):
+                    print(f"[WARN] {p}: i18n.{loc}.name is empty")
+                if not mapping.get('description'):
+                    print(f"[WARN] {p}: i18n.{loc}.description is empty")
+
+    # enableRichTranslate should be boolean if present
+    ert = data.get('enableRichTranslate')
+    if ert is not None and not isinstance(ert, bool):
+        print(f"[WARN] {p}: enableRichTranslate is not boolean: {ert}")
+
+    # priority if present should be integer
+    prio = data.get('priority')
+    if prio is not None and not isinstance(prio, int):
+        print(f"[WARN] {p}: priority should be integer, got: {prio}")
 
     return ok
 

--- a/scripts/check_plugins.py
+++ b/scripts/check_plugins.py
@@ -20,6 +20,14 @@ REQUIRED_TOP = {"id", "version", "name"}
 REQUIRED_I18N = {"zh-CN", "zh-TW"}
 REQUIRED_ENV_KEYS = {"imt_source_field", "imt_trans_field", "imt_yaml_item"}
 REQUIRED_ENV_ADDITIONAL = {"imt_yaml_item", "imt_subtitle_yaml_item"}
+import re
+
+# simple semver-like pattern for extensionVersion (e.g. 1.4.10)
+EXT_VER_RE = re.compile(r"^\d+\.\d+(?:\.\d+)?$")
+# simple URL-ish check for matches entries
+URL_LIKE_RE = re.compile(r"^https?://")
+# placeholder tokens we expect in prompts (warnings if absent)
+COMMON_PLACEHOLDERS = ['{{to}}', '{{imt_source_field}}', '{{imt_trans_field}}', '{{yaml}}']
 
 
 def fail(msg: str):
@@ -95,6 +103,32 @@ def check_file(p: Path) -> bool:
     if not prompt_fields:
         fail(f"[ERROR] {p}: missing any prompt fields (systemPrompt/multiplePrompt/prompt/subtitlePrompt)")
         ok = False
+
+    # extensionVersion format (if present) should look like X.Y or X.Y.Z
+    extver = data.get('extensionVersion')
+    if extver and not EXT_VER_RE.match(str(extver)):
+        fail(f"[ERROR] {p}: extensionVersion '{extver}' does not match expected pattern X.Y[.Z]")
+        ok = False
+
+    # matches entries: if present, should look like http(s) URL patterns
+    matches = data.get('matches')
+    if matches:
+        if not isinstance(matches, list):
+            fail(f"[ERROR] {p}: matches must be a list of URL patterns")
+            ok = False
+        else:
+            for m in matches:
+                if not isinstance(m, str) or not URL_LIKE_RE.match(m):
+                    fail(f"[ERROR] {p}: matches contains non-URL pattern: {m}")
+                    ok = False
+
+    # check prompts for common placeholders — warn if missing (does not fail)
+    for field in ('systemPrompt', 'multiplePrompt', 'prompt', 'subtitlePrompt'):
+        val = data.get(field)
+        if isinstance(val, str):
+            missing = [ph for ph in COMMON_PLACEHOLDERS if ph not in val]
+            if missing:
+                print(f"[WARN] {p}: {field} missing placeholders: {', '.join(missing)}")
 
     return ok
 

--- a/scripts/fix_plugins.py
+++ b/scripts/fix_plugins.py
@@ -1,0 +1,91 @@
+#!/usr/bin/env python3
+"""Apply safe, minimal fixes to plugin YAML files.
+
+Fixes performed:
+- If env.imt_subtitle_yaml_item is missing, add a template using imt_sub_source_field or 'source'.
+- Replace '{{text}}' in prompts with '{{imt_source_field}}'.
+- If env.imt_yaml_item doesn't contain '{{id}}' or '{{imt_source_field}}', replace with a standard template.
+
+This script writes files in-place and prints a summary. Run with care and review changes.
+"""
+from pathlib import Path
+import yaml
+import sys
+
+ROOT = Path(__file__).resolve().parents[1]
+PLUGINS = ROOT / 'plugins'
+
+def read_yaml_block(text: str):
+    if text.lstrip().startswith('```'):
+        parts = text.split('```')
+        if len(parts) >= 2:
+            return parts[1]
+    return text
+
+def write_yaml_block(orig_text: str, new_yaml: str):
+    if orig_text.lstrip().startswith('```'):
+        parts = orig_text.split('```')
+        # keep fences and language marker
+        prefix = parts[0]
+        fence_lang = parts[1][:parts[1].find('\n')].strip()
+        return f"```{fence_lang}\n{new_yaml}\n```"
+    return new_yaml
+
+def process_file(p: Path):
+    text = p.read_text(encoding='utf-8')
+    inner = read_yaml_block(text)
+    try:
+        data = yaml.safe_load(inner)
+    except Exception as e:
+        print(f"skip {p}: parse error: {e}")
+        return False
+    changed = False
+    env = data.get('env') or {}
+    # ensure imt_subtitle_yaml_item exists
+    if 'imt_subtitle_yaml_item' not in env:
+        sub_src = env.get('imt_sub_source_field', 'source')
+        env['imt_subtitle_yaml_item'] = f"- id: {{id}}\n  {{%s}}: {{text}}" % sub_src
+        data['env'] = env
+        changed = True
+
+    # ensure imt_yaml_item contains id and source
+    yaml_item = env.get('imt_yaml_item')
+    if not isinstance(yaml_item, str) or ('{{id}}' not in yaml_item or '{{imt_source_field}}' not in yaml_item):
+        env['imt_yaml_item'] = "- id: {{id}}\n  {{imt_source_field}}: {{text}}"
+        data['env'] = env
+        changed = True
+
+    # replace '{{text}}' in prompt fields with '{{imt_source_field}}'
+    for key in ('systemPrompt', 'multiplePrompt', 'prompt', 'subtitlePrompt'):
+        val = data.get(key)
+        if isinstance(val, str) and '{{text}}' in val:
+            data[key] = val.replace('{{text}}', '{{imt_source_field}}')
+            changed = True
+
+    if changed:
+        new_yaml = yaml.safe_dump(data, allow_unicode=True, sort_keys=False)
+        new_text = write_yaml_block(text, new_yaml)
+        p.write_text(new_text, encoding='utf-8')
+        print(f"fixed: {p}")
+        return True
+    return False
+
+def main():
+    if not PLUGINS.exists():
+        print('no plugins dir')
+        return 1
+    files = sorted(PLUGINS.glob('*.yml'))
+    modified = []
+    for f in files:
+        if process_file(f):
+            modified.append(str(f.name))
+    if modified:
+        print('modified files:')
+        for m in modified:
+            print('-', m)
+    else:
+        print('no changes')
+    return 0
+
+if __name__ == '__main__':
+    sys.exit(main())


### PR DESCRIPTION
# Automated plugin validation: suggested fixes
This PR adds a validator and ran it against existing plugins. Below are automated suggestions per file to help maintainers quickly address warnings reported by the validator.

## Summary of checks added
- YAML parse validity
- required top-level fields (`id`, `version`, `name`)
- `i18n` contains `zh-CN` & `zh-TW`, each with `name` and `description`
- `env` contains `imt_source_field`, `imt_trans_field`, `imt_yaml_item`, `imt_subtitle_yaml_item`
- `id` matches filename
- at least one prompt field present (systemPrompt/multiplePrompt/prompt/subtitlePrompt)
- added extensionVersion, matches, and placeholder checks

---

## Per-file suggested fixes
### VocabularyAssistant.yml
- **WARN**: systemPrompt missing placeholders: {{imt_source_field}}, {{imt_trans_field}}, {{yaml}}
- **WARN**: prompt missing placeholders: {{yaml}}
- **WARN**: subtitlePrompt missing placeholders: {{imt_source_field}}, {{imt_trans_field}}

**Suggested fix:**
- Add the missing placeholders {{imt_source_field}}, {{imt_trans_field}}, {{yaml}} to the prompt text, or ensure the prompt uses the `env` variable names (e.g. `{imt_source_field}`, `{imt_trans_field}`, `{yaml}`, `{to}`).
- Add the missing placeholders {{imt_source_field}}, {{imt_trans_field}} to the prompt text, or ensure the prompt uses the `env` variable names (e.g. `{imt_source_field}`, `{imt_trans_field}`, `{yaml}`, `{to}`).
- Add the missing placeholders {{yaml}} to the prompt text, or ensure the prompt uses the `env` variable names (e.g. `{imt_source_field}`, `{imt_trans_field}`, `{yaml}`, `{to}`).


### ao3.yml
- **WARN**: systemPrompt missing placeholders: {{imt_source_field}}, {{imt_trans_field}}, {{yaml}}

**Suggested fix:**
- Add the missing placeholders {{imt_source_field}}, {{imt_trans_field}}, {{yaml}} to the prompt text, or ensure the prompt uses the `env` variable names (e.g. `{imt_source_field}`, `{imt_trans_field}`, `{yaml}`, `{to}`).


### bilingual-mix.yml
- **WARN**: systemPrompt missing placeholders: {{to}}, {{imt_source_field}}, {{imt_trans_field}}, {{yaml}}
- **WARN**: prompt missing placeholders: {{to}}, {{imt_source_field}}, {{imt_trans_field}}, {{yaml}}
- **WARN**: main prompt (systemPrompt) should include at least one input placeholder ({imt_source_field} or {yaml} or {to})

**Suggested fix:**
- Ensure the main prompt (`systemPrompt` or `multiplePrompt`) includes at least one input placeholder such as `{{imt_source_field}}`, `{{yaml}}` or `{{to}}` so the runtime can inject text.
- Add the missing placeholders {{to}}, {{imt_source_field}}, {{imt_trans_field}}, {{yaml}} to the prompt text, or ensure the prompt uses the `env` variable names (e.g. `{imt_source_field}`, `{imt_trans_field}`, `{yaml}`, `{to}`).


### chess.yml
- **WARN**: systemPrompt missing placeholders: {{imt_source_field}}, {{imt_trans_field}}, {{yaml}}
- **WARN**: multiplePrompt missing placeholders: {{imt_source_field}}
- **WARN**: subtitlePrompt missing placeholders: {{imt_source_field}}, {{imt_trans_field}}

**Suggested fix:**
- Add the missing placeholders {{imt_source_field}}, {{imt_trans_field}}, {{yaml}} to the prompt text, or ensure the prompt uses the `env` variable names (e.g. `{imt_source_field}`, `{imt_trans_field}`, `{yaml}`, `{to}`).
- Add the missing placeholders {{imt_source_field}}, {{imt_trans_field}} to the prompt text, or ensure the prompt uses the `env` variable names (e.g. `{imt_source_field}`, `{imt_trans_field}`, `{yaml}`, `{to}`).
- Add the missing placeholders {{imt_source_field}} to the prompt text, or ensure the prompt uses the `env` variable names (e.g. `{imt_source_field}`, `{imt_trans_field}`, `{yaml}`, `{to}`).


### classicalToModern.yml
- **WARN**: systemPrompt missing placeholders: {{to}}, {{imt_source_field}}, {{imt_trans_field}}, {{yaml}}
- **WARN**: multiplePrompt missing placeholders: {{to}}
- **WARN**: prompt missing placeholders: {{to}}, {{imt_source_field}}, {{imt_trans_field}}, {{yaml}}
- **WARN**: subtitlePrompt missing placeholders: {{to}}, {{imt_source_field}}, {{imt_trans_field}}
- **WARN**: main prompt (systemPrompt) should include at least one input placeholder ({imt_source_field} or {yaml} or {to})

**Suggested fix:**
- Add the missing placeholders {{to}}, {{imt_source_field}}, {{imt_trans_field}} to the prompt text, or ensure the prompt uses the `env` variable names (e.g. `{imt_source_field}`, `{imt_trans_field}`, `{yaml}`, `{to}`).
- Add the missing placeholders {{to}} to the prompt text, or ensure the prompt uses the `env` variable names (e.g. `{imt_source_field}`, `{imt_trans_field}`, `{yaml}`, `{to}`).
- Ensure the main prompt (`systemPrompt` or `multiplePrompt`) includes at least one input placeholder such as `{{imt_source_field}}`, `{{yaml}}` or `{{to}}` so the runtime can inject text.
- Add the missing placeholders {{to}}, {{imt_source_field}}, {{imt_trans_field}}, {{yaml}} to the prompt text, or ensure the prompt uses the `env` variable names (e.g. `{imt_source_field}`, `{imt_trans_field}`, `{yaml}`, `{to}`).


### dbh.yml
- **WARN**: systemPrompt missing placeholders: {{to}}, {{imt_source_field}}, {{imt_trans_field}}, {{yaml}}
- **WARN**: multiplePrompt missing placeholders: {{to}}
- **WARN**: prompt missing placeholders: {{to}}, {{imt_source_field}}, {{imt_trans_field}}, {{yaml}}
- **WARN**: subtitlePrompt missing placeholders: {{to}}, {{imt_source_field}}, {{imt_trans_field}}
- **WARN**: main prompt (systemPrompt) should include at least one input placeholder ({imt_source_field} or {yaml} or {to})

**Suggested fix:**
- Add the missing placeholders {{to}}, {{imt_source_field}}, {{imt_trans_field}} to the prompt text, or ensure the prompt uses the `env` variable names (e.g. `{imt_source_field}`, `{imt_trans_field}`, `{yaml}`, `{to}`).
- Add the missing placeholders {{to}} to the prompt text, or ensure the prompt uses the `env` variable names (e.g. `{imt_source_field}`, `{imt_trans_field}`, `{yaml}`, `{to}`).
- Ensure the main prompt (`systemPrompt` or `multiplePrompt`) includes at least one input placeholder such as `{{imt_source_field}}`, `{{yaml}}` or `{{to}}` so the runtime can inject text.
- Add the missing placeholders {{to}}, {{imt_source_field}}, {{imt_trans_field}}, {{yaml}} to the prompt text, or ensure the prompt uses the `env` variable names (e.g. `{imt_source_field}`, `{imt_trans_field}`, `{yaml}`, `{to}`).


### design.yml
- **WARN**: systemPrompt missing placeholders: {{imt_source_field}}, {{imt_trans_field}}, {{yaml}}
- **WARN**: subtitlePrompt missing placeholders: {{imt_source_field}}, {{imt_trans_field}}

**Suggested fix:**
- Add the missing placeholders {{imt_source_field}}, {{imt_trans_field}}, {{yaml}} to the prompt text, or ensure the prompt uses the `env` variable names (e.g. `{imt_source_field}`, `{imt_trans_field}`, `{yaml}`, `{to}`).
- Add the missing placeholders {{imt_source_field}}, {{imt_trans_field}} to the prompt text, or ensure the prompt uses the `env` variable names (e.g. `{imt_source_field}`, `{imt_trans_field}`, `{yaml}`, `{to}`).


### ebook.yml
- **WARN**: systemPrompt missing placeholders: {{imt_source_field}}, {{imt_trans_field}}, {{yaml}}
- **WARN**: subtitlePrompt missing placeholders: {{imt_source_field}}, {{imt_trans_field}}

**Suggested fix:**
- Add the missing placeholders {{imt_source_field}}, {{imt_trans_field}}, {{yaml}} to the prompt text, or ensure the prompt uses the `env` variable names (e.g. `{imt_source_field}`, `{imt_trans_field}`, `{yaml}`, `{to}`).
- Add the missing placeholders {{imt_source_field}}, {{imt_trans_field}} to the prompt text, or ensure the prompt uses the `env` variable names (e.g. `{imt_source_field}`, `{imt_trans_field}`, `{yaml}`, `{to}`).


### ecommerce.yml
- **WARN**: systemPrompt missing placeholders: {{imt_source_field}}, {{imt_trans_field}}, {{yaml}}
- **WARN**: subtitlePrompt missing placeholders: {{imt_source_field}}, {{imt_trans_field}}

**Suggested fix:**
- Add the missing placeholders {{imt_source_field}}, {{imt_trans_field}}, {{yaml}} to the prompt text, or ensure the prompt uses the `env` variable names (e.g. `{imt_source_field}`, `{imt_trans_field}`, `{yaml}`, `{to}`).
- Add the missing placeholders {{imt_source_field}}, {{imt_trans_field}} to the prompt text, or ensure the prompt uses the `env` variable names (e.g. `{imt_source_field}`, `{imt_trans_field}`, `{yaml}`, `{to}`).


### fiction.yml
- **WARN**: systemPrompt missing placeholders: {{imt_source_field}}, {{imt_trans_field}}, {{yaml}}
- **WARN**: subtitlePrompt missing placeholders: {{imt_source_field}}, {{imt_trans_field}}

**Suggested fix:**
- Add the missing placeholders {{imt_source_field}}, {{imt_trans_field}}, {{yaml}} to the prompt text, or ensure the prompt uses the `env` variable names (e.g. `{imt_source_field}`, `{imt_trans_field}`, `{yaml}`, `{to}`).
- Add the missing placeholders {{imt_source_field}}, {{imt_trans_field}} to the prompt text, or ensure the prompt uses the `env` variable names (e.g. `{imt_source_field}`, `{imt_trans_field}`, `{yaml}`, `{to}`).


### financial.yml
- **WARN**: systemPrompt missing placeholders: {{imt_source_field}}, {{imt_trans_field}}, {{yaml}}

**Suggested fix:**
- Add the missing placeholders {{imt_source_field}}, {{imt_trans_field}}, {{yaml}} to the prompt text, or ensure the prompt uses the `env` variable names (e.g. `{imt_source_field}`, `{imt_trans_field}`, `{yaml}`, `{to}`).


### game.yml
- **WARN**: systemPrompt missing placeholders: {{to}}, {{imt_source_field}}, {{imt_trans_field}}, {{yaml}}
- **WARN**: subtitlePrompt missing placeholders: {{imt_source_field}}, {{imt_trans_field}}
- **WARN**: main prompt (systemPrompt) should include at least one input placeholder ({imt_source_field} or {yaml} or {to})

**Suggested fix:**
- Add the missing placeholders {{imt_source_field}}, {{imt_trans_field}} to the prompt text, or ensure the prompt uses the `env` variable names (e.g. `{imt_source_field}`, `{imt_trans_field}`, `{yaml}`, `{to}`).
- Ensure the main prompt (`systemPrompt` or `multiplePrompt`) includes at least one input placeholder such as `{{imt_source_field}}`, `{{yaml}}` or `{{to}}` so the runtime can inject text.
- Add the missing placeholders {{to}}, {{imt_source_field}}, {{imt_trans_field}}, {{yaml}} to the prompt text, or ensure the prompt uses the `env` variable names (e.g. `{imt_source_field}`, `{imt_trans_field}`, `{yaml}`, `{to}`).


### github.yml
- **WARN**: systemPrompt missing placeholders: {{to}}, {{imt_source_field}}, {{imt_trans_field}}, {{yaml}}
- **WARN**: multiplePrompt missing placeholders: {{imt_source_field}}
- **WARN**: main prompt (systemPrompt) should include at least one input placeholder ({imt_source_field} or {yaml} or {to})

**Suggested fix:**
- Ensure the main prompt (`systemPrompt` or `multiplePrompt`) includes at least one input placeholder such as `{{imt_source_field}}`, `{{yaml}}` or `{{to}}` so the runtime can inject text.
- Add the missing placeholders {{imt_source_field}} to the prompt text, or ensure the prompt uses the `env` variable names (e.g. `{imt_source_field}`, `{imt_trans_field}`, `{yaml}`, `{to}`).
- Add the missing placeholders {{to}}, {{imt_source_field}}, {{imt_trans_field}}, {{yaml}} to the prompt text, or ensure the prompt uses the `env` variable names (e.g. `{imt_source_field}`, `{imt_trans_field}`, `{yaml}`, `{to}`).


### legal.yml
- **WARN**: systemPrompt missing placeholders: {{imt_source_field}}, {{imt_trans_field}}, {{yaml}}

**Suggested fix:**
- Add the missing placeholders {{imt_source_field}}, {{imt_trans_field}}, {{yaml}} to the prompt text, or ensure the prompt uses the `env` variable names (e.g. `{imt_source_field}`, `{imt_trans_field}`, `{yaml}`, `{to}`).


### medical.yml
- **WARN**: systemPrompt missing placeholders: {{imt_source_field}}, {{imt_trans_field}}, {{yaml}}

**Suggested fix:**
- Add the missing placeholders {{imt_source_field}}, {{imt_trans_field}}, {{yaml}} to the prompt text, or ensure the prompt uses the `env` variable names (e.g. `{imt_source_field}`, `{imt_trans_field}`, `{yaml}`, `{to}`).


### music.yml
- **WARN**: systemPrompt missing placeholders: {{imt_source_field}}, {{imt_trans_field}}, {{yaml}}

**Suggested fix:**
- Add the missing placeholders {{imt_source_field}}, {{imt_trans_field}}, {{yaml}} to the prompt text, or ensure the prompt uses the `env` variable names (e.g. `{imt_source_field}`, `{imt_trans_field}`, `{yaml}`, `{to}`).


### news.yml
- **WARN**: systemPrompt missing placeholders: {{imt_source_field}}, {{imt_trans_field}}, {{yaml}}

**Suggested fix:**
- Add the missing placeholders {{imt_source_field}}, {{imt_trans_field}}, {{yaml}} to the prompt text, or ensure the prompt uses the `env` variable names (e.g. `{imt_source_field}`, `{imt_trans_field}`, `{yaml}`, `{to}`).


### paper.yml
- **WARN**: systemPrompt missing placeholders: {{imt_source_field}}, {{imt_trans_field}}, {{yaml}}

**Suggested fix:**
- Add the missing placeholders {{imt_source_field}}, {{imt_trans_field}}, {{yaml}} to the prompt text, or ensure the prompt uses the `env` variable names (e.g. `{imt_source_field}`, `{imt_trans_field}`, `{yaml}`, `{to}`).


### paragraph-summarizer-expert.yml
- **WARN**: systemPrompt missing placeholders: {{imt_source_field}}, {{imt_trans_field}}, {{yaml}}
- **WARN**: multiplePrompt missing placeholders: {{imt_source_field}}, {{imt_trans_field}}, {{yaml}}
- **WARN**: prompt missing placeholders: {{imt_source_field}}, {{imt_trans_field}}, {{yaml}}
- **WARN**: subtitlePrompt missing placeholders: {{imt_source_field}}, {{imt_trans_field}}, {{yaml}}

**Suggested fix:**
- Add the missing placeholders {{imt_source_field}}, {{imt_trans_field}}, {{yaml}} to the prompt text, or ensure the prompt uses the `env` variable names (e.g. `{imt_source_field}`, `{imt_trans_field}`, `{yaml}`, `{to}`).


### paraphrase.yml
- **WARN**: systemPrompt missing placeholders: {{to}}, {{imt_source_field}}, {{imt_trans_field}}, {{yaml}}
- **WARN**: multiplePrompt missing placeholders: {{imt_source_field}}, {{imt_trans_field}}
- **WARN**: prompt missing placeholders: {{imt_source_field}}, {{imt_trans_field}}
- **WARN**: main prompt (systemPrompt) should include at least one input placeholder ({imt_source_field} or {yaml} or {to})

**Suggested fix:**
- Add the missing placeholders {{imt_source_field}}, {{imt_trans_field}} to the prompt text, or ensure the prompt uses the `env` variable names (e.g. `{imt_source_field}`, `{imt_trans_field}`, `{yaml}`, `{to}`).
- Ensure the main prompt (`systemPrompt` or `multiplePrompt`) includes at least one input placeholder such as `{{imt_source_field}}`, `{{yaml}}` or `{{to}}` so the runtime can inject text.
- Add the missing placeholders {{to}}, {{imt_source_field}}, {{imt_trans_field}}, {{yaml}} to the prompt text, or ensure the prompt uses the `env` variable names (e.g. `{imt_source_field}`, `{imt_trans_field}`, `{yaml}`, `{to}`).


### plain-english.yml
- **WARN**: systemPrompt missing placeholders: {{to}}, {{imt_source_field}}, {{imt_trans_field}}, {{yaml}}
- **WARN**: multiplePrompt missing placeholders: {{to}}, {{imt_source_field}}, {{imt_trans_field}}, {{yaml}}
- **WARN**: prompt missing placeholders: {{to}}, {{imt_source_field}}, {{imt_trans_field}}, {{yaml}}
- **WARN**: subtitlePrompt missing placeholders: {{to}}, {{imt_source_field}}, {{imt_trans_field}}, {{yaml}}
- **WARN**: main prompt (systemPrompt) should include at least one input placeholder ({imt_source_field} or {yaml} or {to})

**Suggested fix:**
- Ensure the main prompt (`systemPrompt` or `multiplePrompt`) includes at least one input placeholder such as `{{imt_source_field}}`, `{{yaml}}` or `{{to}}` so the runtime can inject text.
- Add the missing placeholders {{to}}, {{imt_source_field}}, {{imt_trans_field}}, {{yaml}} to the prompt text, or ensure the prompt uses the `env` variable names (e.g. `{imt_source_field}`, `{imt_trans_field}`, `{yaml}`, `{to}`).


### reddit.yml
- **WARN**: systemPrompt missing placeholders: {{to}}, {{imt_source_field}}, {{imt_trans_field}}, {{yaml}}
- **WARN**: multiplePrompt missing placeholders: {{imt_source_field}}
- **WARN**: main prompt (systemPrompt) should include at least one input placeholder ({imt_source_field} or {yaml} or {to})

**Suggested fix:**
- Ensure the main prompt (`systemPrompt` or `multiplePrompt`) includes at least one input placeholder such as `{{imt_source_field}}`, `{{yaml}}` or `{{to}}` so the runtime can inject text.
- Add the missing placeholders {{imt_source_field}} to the prompt text, or ensure the prompt uses the `env` variable names (e.g. `{imt_source_field}`, `{imt_trans_field}`, `{yaml}`, `{to}`).
- Add the missing placeholders {{to}}, {{imt_source_field}}, {{imt_trans_field}}, {{yaml}} to the prompt text, or ensure the prompt uses the `env` variable names (e.g. `{imt_source_field}`, `{imt_trans_field}`, `{yaml}`, `{to}`).


### subliminal_lingo.yml
- **WARN**: systemPrompt missing placeholders: {{to}}, {{imt_source_field}}, {{imt_trans_field}}, {{yaml}}
- **WARN**: multiplePrompt missing placeholders: {{to}}, {{imt_source_field}}, {{imt_trans_field}}
- **WARN**: prompt missing placeholders: {{to}}, {{imt_source_field}}, {{imt_trans_field}}, {{yaml}}
- **WARN**: subtitlePrompt missing placeholders: {{to}}, {{imt_source_field}}, {{imt_trans_field}}
- **WARN**: main prompt (systemPrompt) should include at least one input placeholder ({imt_source_field} or {yaml} or {to})

**Suggested fix:**
- Add the missing placeholders {{to}}, {{imt_source_field}}, {{imt_trans_field}} to the prompt text, or ensure the prompt uses the `env` variable names (e.g. `{imt_source_field}`, `{imt_trans_field}`, `{yaml}`, `{to}`).
- Ensure the main prompt (`systemPrompt` or `multiplePrompt`) includes at least one input placeholder such as `{{imt_source_field}}`, `{{yaml}}` or `{{to}}` so the runtime can inject text.
- Add the missing placeholders {{to}}, {{imt_source_field}}, {{imt_trans_field}}, {{yaml}} to the prompt text, or ensure the prompt uses the `env` variable names (e.g. `{imt_source_field}`, `{imt_trans_field}`, `{yaml}`, `{to}`).


### tech.yml
- **WARN**: systemPrompt missing placeholders: {{imt_source_field}}, {{imt_trans_field}}, {{yaml}}
- **WARN**: subtitlePrompt missing placeholders: {{imt_source_field}}, {{imt_trans_field}}

**Suggested fix:**
- Add the missing placeholders {{imt_source_field}}, {{imt_trans_field}}, {{yaml}} to the prompt text, or ensure the prompt uses the `env` variable names (e.g. `{imt_source_field}`, `{imt_trans_field}`, `{yaml}`, `{to}`).
- Add the missing placeholders {{imt_source_field}}, {{imt_trans_field}} to the prompt text, or ensure the prompt uses the `env` variable names (e.g. `{imt_source_field}`, `{imt_trans_field}`, `{yaml}`, `{to}`).


### twitter.yml
- **WARN**: systemPrompt missing placeholders: {{to}}, {{imt_source_field}}, {{imt_trans_field}}, {{yaml}}
- **WARN**: multiplePrompt missing placeholders: {{imt_source_field}}
- **WARN**: main prompt (systemPrompt) should include at least one input placeholder ({imt_source_field} or {yaml} or {to})

**Suggested fix:**
- Ensure the main prompt (`systemPrompt` or `multiplePrompt`) includes at least one input placeholder such as `{{imt_source_field}}`, `{{yaml}}` or `{{to}}` so the runtime can inject text.
- Add the missing placeholders {{imt_source_field}} to the prompt text, or ensure the prompt uses the `env` variable names (e.g. `{imt_source_field}`, `{imt_trans_field}`, `{yaml}`, `{to}`).
- Add the missing placeholders {{to}}, {{imt_source_field}}, {{imt_trans_field}}, {{yaml}} to the prompt text, or ensure the prompt uses the `env` variable names (e.g. `{imt_source_field}`, `{imt_trans_field}`, `{yaml}`, `{to}`).


### web3.yml
- **WARN**: systemPrompt missing placeholders: {{to}}, {{imt_source_field}}, {{imt_trans_field}}, {{yaml}}
- **WARN**: subtitlePrompt missing placeholders: {{imt_source_field}}, {{imt_trans_field}}
- **WARN**: main prompt (systemPrompt) should include at least one input placeholder ({imt_source_field} or {yaml} or {to})

**Suggested fix:**
- Add the missing placeholders {{imt_source_field}}, {{imt_trans_field}} to the prompt text, or ensure the prompt uses the `env` variable names (e.g. `{imt_source_field}`, `{imt_trans_field}`, `{yaml}`, `{to}`).
- Ensure the main prompt (`systemPrompt` or `multiplePrompt`) includes at least one input placeholder such as `{{imt_source_field}}`, `{{yaml}}` or `{{to}}` so the runtime can inject text.
- Add the missing placeholders {{to}}, {{imt_source_field}}, {{imt_trans_field}}, {{yaml}} to the prompt text, or ensure the prompt uses the `env` variable names (e.g. `{imt_source_field}`, `{imt_trans_field}`, `{yaml}`, `{to}`).


### wordByWord.yml
- **WARN**: systemPrompt missing placeholders: {{to}}, {{imt_source_field}}, {{imt_trans_field}}, {{yaml}}
- **WARN**: multiplePrompt missing placeholders: {{to}}, {{imt_source_field}}, {{imt_trans_field}}
- **WARN**: prompt missing placeholders: {{to}}, {{imt_source_field}}, {{imt_trans_field}}, {{yaml}}
- **WARN**: main prompt (systemPrompt) should include at least one input placeholder ({imt_source_field} or {yaml} or {to})

**Suggested fix:**
- Add the missing placeholders {{to}}, {{imt_source_field}}, {{imt_trans_field}} to the prompt text, or ensure the prompt uses the `env` variable names (e.g. `{imt_source_field}`, `{imt_trans_field}`, `{yaml}`, `{to}`).
- Ensure the main prompt (`systemPrompt` or `multiplePrompt`) includes at least one input placeholder such as `{{imt_source_field}}`, `{{yaml}}` or `{{to}}` so the runtime can inject text.
- Add the missing placeholders {{to}}, {{imt_source_field}}, {{imt_trans_field}}, {{yaml}} to the prompt text, or ensure the prompt uses the `env` variable names (e.g. `{imt_source_field}`, `{imt_trans_field}`, `{yaml}`, `{to}`).


### wyw.yml
- **WARN**: systemPrompt missing placeholders: {{to}}, {{imt_source_field}}, {{imt_trans_field}}, {{yaml}}
- **WARN**: multiplePrompt missing placeholders: {{to}}
- **WARN**: prompt missing placeholders: {{to}}, {{imt_source_field}}, {{imt_trans_field}}, {{yaml}}
- **WARN**: subtitlePrompt missing placeholders: {{to}}, {{imt_source_field}}, {{imt_trans_field}}
- **WARN**: main prompt (systemPrompt) should include at least one input placeholder ({imt_source_field} or {yaml} or {to})

**Suggested fix:**
- Add the missing placeholders {{to}}, {{imt_source_field}}, {{imt_trans_field}} to the prompt text, or ensure the prompt uses the `env` variable names (e.g. `{imt_source_field}`, `{imt_trans_field}`, `{yaml}`, `{to}`).
- Add the missing placeholders {{to}} to the prompt text, or ensure the prompt uses the `env` variable names (e.g. `{imt_source_field}`, `{imt_trans_field}`, `{yaml}`, `{to}`).
- Ensure the main prompt (`systemPrompt` or `multiplePrompt`) includes at least one input placeholder such as `{{imt_source_field}}`, `{{yaml}}` or `{{to}}` so the runtime can inject text.
- Add the missing placeholders {{to}}, {{imt_source_field}}, {{imt_trans_field}}, {{yaml}} to the prompt text, or ensure the prompt uses the `env` variable names (e.g. `{imt_source_field}`, `{imt_trans_field}`, `{yaml}`, `{to}`).

